### PR TITLE
Add unit tests for DAO and service classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,11 @@
             <version>8.0.33</version>
         </dependency>
 
-        <!-- JUnit (for testing) -->
+        <!-- JUnit 5 (for testing) -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -40,5 +40,26 @@
     </dependencies>
     <build>
         <finalName>PahanaEdu</finalName>
+        <plugins>
+            <!-- Maven Surefire Plugin for running tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
+            <!-- Maven Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,22 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Mockito (for testing) -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito JUnit 5 extension -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.1.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- dotenv-java -->
         <dependency>
             <groupId>io.github.cdimascio</groupId>
@@ -48,6 +64,8 @@
                 <version>3.0.0-M9</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <!-- Fix for mocking not working in jdk 24 https://stackoverflow.com/a/79615061 -->
+                    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
             <!-- Maven Compiler Plugin -->

--- a/src/main/java/com/pahanaedu/dao/BillDAO.java
+++ b/src/main/java/com/pahanaedu/dao/BillDAO.java
@@ -30,7 +30,7 @@ public class BillDAO extends BaseDAO {
             while (resultSet.next()) {
                 bills.add(mapResultSetToBill(resultSet));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -54,7 +54,7 @@ public class BillDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToBill(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -80,7 +80,7 @@ public class BillDAO extends BaseDAO {
             while (resultSet.next()) {
                 bills.add(mapResultSetToBill(resultSet));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -111,7 +111,7 @@ public class BillDAO extends BaseDAO {
                 }
                 return true;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -136,7 +136,7 @@ public class BillDAO extends BaseDAO {
             statement.setInt(7, bill.getBillId());
 
             return statement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -151,7 +151,7 @@ public class BillDAO extends BaseDAO {
 
             statement.setInt(1, billId);
             return statement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -170,7 +170,7 @@ public class BillDAO extends BaseDAO {
             statement.setInt(2, billId);
 
             return statement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -192,7 +192,7 @@ public class BillDAO extends BaseDAO {
                 BigDecimal total = resultSet.getBigDecimal("total");
                 return total != null ? total : BigDecimal.ZERO;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/com/pahanaedu/dao/BillItemDAO.java
+++ b/src/main/java/com/pahanaedu/dao/BillItemDAO.java
@@ -27,7 +27,7 @@ public class BillItemDAO extends BaseDAO {
             while (resultSet.next()) {
                 billItems.add(mapResultSetToBillItem(resultSet));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -53,7 +53,7 @@ public class BillItemDAO extends BaseDAO {
             while (resultSet.next()) {
                 billItems.add(mapResultSetToBillItem(resultSet));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -77,7 +77,7 @@ public class BillItemDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToBillItem(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -106,7 +106,7 @@ public class BillItemDAO extends BaseDAO {
                 }
                 return true;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -130,7 +130,7 @@ public class BillItemDAO extends BaseDAO {
             statement.setInt(6, billItem.getBillItemId());
 
             return statement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -145,7 +145,7 @@ public class BillItemDAO extends BaseDAO {
 
             statement.setInt(1, billItemId);
             return statement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -160,7 +160,7 @@ public class BillItemDAO extends BaseDAO {
 
             statement.setInt(1, billId);
             return statement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -197,7 +197,7 @@ public class BillItemDAO extends BaseDAO {
             }
 
             return affectedRows.length == billItems.size();
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/com/pahanaedu/dao/CategoryDAO.java
+++ b/src/main/java/com/pahanaedu/dao/CategoryDAO.java
@@ -13,14 +13,14 @@ public class CategoryDAO extends BaseDAO {
         String query = "SELECT * FROM categories WHERE deleted_at IS NULL ORDER BY name";
 
         try (Connection connection = getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(query)) {
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(query)) {
 
             while (resultSet.next()) {
                 Category category = mapResultSetToCategory(resultSet);
                 categories.add(category);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -31,7 +31,7 @@ public class CategoryDAO extends BaseDAO {
         String query = "SELECT * FROM categories WHERE category_id = ? AND deleted_at IS NULL";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
 
             statement.setInt(1, categoryId);
             ResultSet resultSet = statement.executeQuery();
@@ -39,7 +39,7 @@ public class CategoryDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToCategory(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -50,7 +50,7 @@ public class CategoryDAO extends BaseDAO {
         String query = "INSERT INTO categories (name, description) VALUES (?, ?)";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+                PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
 
             statement.setString(1, category.getName());
             statement.setString(2, category.getDescription());
@@ -64,7 +64,7 @@ public class CategoryDAO extends BaseDAO {
                 }
                 return true;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -75,7 +75,7 @@ public class CategoryDAO extends BaseDAO {
         String query = "UPDATE categories SET name = ?, description = ? WHERE category_id = ? AND deleted_at IS NULL";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
 
             statement.setString(1, category.getName());
             statement.setString(2, category.getDescription());
@@ -83,7 +83,7 @@ public class CategoryDAO extends BaseDAO {
 
             int rowsAffected = statement.executeUpdate();
             return rowsAffected > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -94,12 +94,12 @@ public class CategoryDAO extends BaseDAO {
         String query = "UPDATE categories SET deleted_at = CURRENT_TIMESTAMP WHERE category_id = ?";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
 
             statement.setInt(1, categoryId);
             int rowsAffected = statement.executeUpdate();
             return rowsAffected > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -110,7 +110,7 @@ public class CategoryDAO extends BaseDAO {
         String query = "SELECT COUNT(*) FROM categories WHERE name = ? AND deleted_at IS NULL";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
 
             statement.setString(1, name);
             ResultSet resultSet = statement.executeQuery();
@@ -118,7 +118,7 @@ public class CategoryDAO extends BaseDAO {
             if (resultSet.next()) {
                 return resultSet.getInt(1) > 0;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -129,7 +129,7 @@ public class CategoryDAO extends BaseDAO {
         String query = "SELECT COUNT(*) FROM categories WHERE name = ? AND category_id != ? AND deleted_at IS NULL";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
 
             statement.setString(1, name);
             statement.setInt(2, categoryId);
@@ -138,7 +138,7 @@ public class CategoryDAO extends BaseDAO {
             if (resultSet.next()) {
                 return resultSet.getInt(1) > 0;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -149,7 +149,7 @@ public class CategoryDAO extends BaseDAO {
         String query = "SELECT COUNT(*) FROM items WHERE category_id = ? AND deleted_at IS NULL";
 
         try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
 
             statement.setInt(1, categoryId);
             ResultSet resultSet = statement.executeQuery();
@@ -157,7 +157,7 @@ public class CategoryDAO extends BaseDAO {
             if (resultSet.next()) {
                 return resultSet.getInt(1) > 0;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -169,13 +169,13 @@ public class CategoryDAO extends BaseDAO {
         String query = "SELECT name FROM categories WHERE deleted_at IS NULL ORDER BY name";
 
         try (Connection connection = getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(query)) {
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(query)) {
 
             while (resultSet.next()) {
                 categories.add(resultSet.getString("name"));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/com/pahanaedu/dao/CustomerDAO.java
+++ b/src/main/java/com/pahanaedu/dao/CustomerDAO.java
@@ -20,7 +20,7 @@ public class CustomerDAO extends BaseDAO {
                 Customer customer = mapResultSetToCustomer(resultSet);
                 customers.add(customer);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -39,7 +39,7 @@ public class CustomerDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToCustomer(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -124,7 +124,7 @@ public class CustomerDAO extends BaseDAO {
             statement.setInt(1, customerId);
             int rowsAffected = statement.executeUpdate();
             return rowsAffected > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/com/pahanaedu/dao/ItemDAO.java
+++ b/src/main/java/com/pahanaedu/dao/ItemDAO.java
@@ -23,7 +23,7 @@ public class ItemDAO extends BaseDAO {
                 Item item = mapResultSetToItem(resultSet);
                 items.add(item);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -44,7 +44,7 @@ public class ItemDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToItem(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -67,7 +67,7 @@ public class ItemDAO extends BaseDAO {
                 Item item = mapResultSetToItem(resultSet);
                 items.add(item);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -94,7 +94,7 @@ public class ItemDAO extends BaseDAO {
                 }
                 return true;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -116,7 +116,7 @@ public class ItemDAO extends BaseDAO {
 
             int rowsAffected = statement.executeUpdate();
             return rowsAffected > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -132,7 +132,7 @@ public class ItemDAO extends BaseDAO {
             statement.setInt(1, itemId);
             int rowsAffected = statement.executeUpdate();
             return rowsAffected > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -151,7 +151,7 @@ public class ItemDAO extends BaseDAO {
             if (resultSet.next()) {
                 return resultSet.getInt(1) > 0;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -171,7 +171,7 @@ public class ItemDAO extends BaseDAO {
             if (resultSet.next()) {
                 return resultSet.getInt(1) > 0;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -189,7 +189,7 @@ public class ItemDAO extends BaseDAO {
             while (resultSet.next()) {
                 items.add(resultSet.getString("name"));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/com/pahanaedu/dao/UserDAO.java
+++ b/src/main/java/com/pahanaedu/dao/UserDAO.java
@@ -20,7 +20,7 @@ public class UserDAO extends BaseDAO {
             while (resultSet.next()) {
                 users.add(mapResultSetToUser(resultSet));
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -49,7 +49,7 @@ public class UserDAO extends BaseDAO {
                     }
                 }
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return null;
@@ -67,7 +67,7 @@ public class UserDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToUser(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return null;
@@ -100,7 +100,7 @@ public class UserDAO extends BaseDAO {
             }
 
             return preparedStatement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return false;
@@ -114,7 +114,7 @@ public class UserDAO extends BaseDAO {
 
             preparedStatement.setInt(1, userId);
             return preparedStatement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return false;
@@ -133,7 +133,7 @@ public class UserDAO extends BaseDAO {
             if (resultSet.next()) {
                 return resultSet.getInt(1) > 0;
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return false;
@@ -154,7 +154,7 @@ public class UserDAO extends BaseDAO {
             if (resultSet.next()) {
                 return mapResultSetToUser(resultSet);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return null;
@@ -167,7 +167,7 @@ public class UserDAO extends BaseDAO {
 
             preparedStatement.setInt(1, userId);
             return preparedStatement.executeUpdate() > 0;
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return false;

--- a/src/main/java/com/pahanaedu/enums/PaymentMethod.java
+++ b/src/main/java/com/pahanaedu/enums/PaymentMethod.java
@@ -36,18 +36,17 @@ public enum PaymentMethod {
         }
     }
 
-    public String getIconClass() {
-        switch (this) {
-            case CASH:
-                return "icon-cash";
-            case CREDIT_CARD:
-                return "icon-credit-card";
-            case DEBIT_CARD:
-                return "icon-debit-card";
-            case BANK_TRANSFER:
-                return "icon-bank-transfer";
-            default:
-                return "icon-payment";
+    public static PaymentMethod fromString(String value) {
+        if (value == null) {
+            return null;
         }
+
+        for (PaymentMethod method : PaymentMethod.values()) {
+            if (method.name().equalsIgnoreCase(value)) {
+                return method;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid payment method: " + value);
     }
 }

--- a/src/main/java/com/pahanaedu/enums/PaymentStatus.java
+++ b/src/main/java/com/pahanaedu/enums/PaymentStatus.java
@@ -30,4 +30,18 @@ public enum PaymentStatus {
                 return "status-default";
         }
     }
+
+    public static PaymentStatus fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        for (PaymentStatus status : PaymentStatus.values()) {
+            if (status.name().equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid payment status: " + value);
+    }
 }

--- a/src/main/java/com/pahanaedu/enums/UserRole.java
+++ b/src/main/java/com/pahanaedu/enums/UserRole.java
@@ -4,6 +4,17 @@ public enum UserRole {
     ADMIN,
     CASHIER;
 
+    public String getDisplayName() {
+        switch (this) {
+            case ADMIN:
+                return "Administrator";
+            case CASHIER:
+                return "Cashier";
+            default:
+                return name();
+        }
+    }
+
     public String getCssClass() {
         return "role-" + name().toLowerCase();
     }

--- a/src/main/java/com/pahanaedu/service/AuthService.java
+++ b/src/main/java/com/pahanaedu/service/AuthService.java
@@ -10,6 +10,11 @@ public class AuthService {
         this.userDAO = new UserDAO();
     }
 
+    // Added to inject mock class in tests
+    public AuthService(UserDAO userDAO) {
+        this.userDAO = userDAO;
+    }
+
     // Authenticate user with email and password
     public User authenticate(String email, String password) {
         if (email == null || password == null || email.trim().isEmpty() || password.trim().isEmpty()) {

--- a/src/main/java/com/pahanaedu/service/AuthService.java
+++ b/src/main/java/com/pahanaedu/service/AuthService.java
@@ -3,9 +3,6 @@ package com.pahanaedu.service;
 import com.pahanaedu.dao.UserDAO;
 import com.pahanaedu.model.User;
 
-/**
- * Service class for user authentication and authorization
- */
 public class AuthService {
     private final UserDAO userDAO;
 

--- a/src/test/java/com/pahanaedu/dao/BillDAOTest.java
+++ b/src/test/java/com/pahanaedu/dao/BillDAOTest.java
@@ -1,0 +1,327 @@
+package com.pahanaedu.dao;
+
+import com.pahanaedu.helpers.DatabaseHelper;
+import com.pahanaedu.model.Bill;
+import com.pahanaedu.model.BillItem;
+import com.pahanaedu.enums.PaymentMethod;
+import com.pahanaedu.enums.PaymentStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BillDAOTest {
+
+    private BillDAO billDAO;
+
+    @BeforeAll
+    static void setupDatabase() throws SQLException {
+
+        try (Connection connection = DatabaseHelper.getInstance().getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+            statement.execute("DELETE FROM bill_items");
+            statement.execute("DELETE FROM bills");
+            statement.execute("DELETE FROM items");
+            statement.execute("DELETE FROM categories");
+            statement.execute("DELETE FROM customers");
+            statement.execute("DELETE FROM users");
+            statement.execute("ALTER TABLE bill_items AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE bills AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE items AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE categories AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE customers AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE users AUTO_INCREMENT = 1");
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+            statement.execute(
+                    "INSERT INTO users (user_id, email, password, first_name, last_name, role, created_at, updated_at) VALUES "
+                            +
+                            "(1, 'admin@pahanaedu.com', 'admin123', 'Admin', 'User', 'ADMIN', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO customers (customer_id, account_number, name, address, telephone, email, created_at, updated_at) VALUES "
+                            +
+                            "(1, 000001, 'John Doe', '123 Main St, Colombo', '0771234567', 'john.doe@email.com', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO bills (bill_id, customer_id, user_id, total_amount, payment_status, payment_method, notes, created_at, updated_at) VALUES "
+                            +
+                            "(1, 1, 1, 1700.00, 'PAID', 'CASH', 'Test bill', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO categories (category_id, name, description, created_at, updated_at) VALUES "
+                            +
+                            "(1, 'Books', 'Academic books and materials', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO items (item_id, category_id, name, description, unit_price, created_at, updated_at) VALUES "
+                            +
+                            "(1, 1, 'Mathematics Textbook', 'Grade 10 Mathematics Textbook', 850.00, NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO bill_items (bill_item_id, bill_id, item_id, quantity, unit_price, line_total, created_at, updated_at) VALUES "
+                            +
+                            "(1, 1, 1, 2, 850.00, 1700.00, NOW(), NOW())");
+
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        billDAO = new BillDAO();
+    }
+
+    @Test
+    void shouldRetrieveExistingBills() {
+        List<Bill> bills = billDAO.getAllBills();
+
+        assertNotNull(bills, "Bills list should not be null");
+        assertFalse(bills.isEmpty(), "Should have bills from seed data");
+
+        assertTrue(bills.size() >= 1, "Should have at least 1 focused test bill");
+
+        Bill firstBill = bills.get(0);
+        assertNotNull(firstBill.getCustomer(), "Bill should have customer populated");
+        assertNotNull(firstBill.getUser(), "Bill should have user populated");
+        assertNotNull(firstBill.getCustomer().getName(), "Customer should have name");
+        assertNotNull(firstBill.getUser().getFirstName(), "User should have first name");
+    }
+
+    @Test
+    void shouldRetrieveBillById() {
+        Bill bill = billDAO.getBillById(1);
+
+        assertNotNull(bill, "Should find bill with ID 1");
+        assertEquals(new BigDecimal("1700.00"), bill.getTotalAmount(), "Bill total should match focused test data");
+        assertEquals(PaymentStatus.PAID, bill.getPaymentStatus(), "Payment status should match focused test data");
+        assertEquals(PaymentMethod.CASH, bill.getPaymentMethod(), "Payment method should match focused test data");
+        assertEquals("Test bill", bill.getNotes(), "Notes should match focused test data");
+
+        assertNotNull(bill.getCustomer(), "Bill should have customer populated");
+        assertNotNull(bill.getUser(), "Bill should have user populated");
+        assertEquals("John Doe", bill.getCustomer().getName(), "Customer name should match focused test data");
+        assertEquals("Admin", bill.getUser().getFirstName(), "User first name should match focused test data");
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentBill() {
+        Bill result = billDAO.getBillById(99999);
+        assertNull(result, "Non-existent bill should return null");
+    }
+
+    @Test
+    void shouldHandleInvalidIds() {
+        assertNull(billDAO.getBillById(-1), "Negative ID should return null");
+        assertNull(billDAO.getBillById(0), "Zero ID should return null");
+    }
+
+    @Test
+    void shouldCreateNewBill() {
+        Bill newBill = new Bill();
+        newBill.setCustomerId(1);
+        newBill.setUserId(1);
+        newBill.setTotalAmount(new BigDecimal("500.00"));
+        newBill.setPaymentStatus(PaymentStatus.PENDING);
+        newBill.setPaymentMethod(PaymentMethod.CREDIT_CARD);
+        newBill.setNotes("Test bill creation");
+
+        boolean created = billDAO.createBill(newBill);
+        assertTrue(created, "Should successfully create new bill");
+
+        List<Bill> bills = billDAO.getAllBills();
+        boolean found = bills.stream()
+                .anyMatch(b -> "Test bill creation".equals(b.getNotes()));
+        assertTrue(found, "New bill should appear in bills list");
+    }
+
+    @Test
+    void shouldUpdateExistingBill() {
+
+        Bill testBill = new Bill();
+        testBill.setCustomerId(1);
+        testBill.setUserId(1);
+        testBill.setTotalAmount(new BigDecimal("300.00"));
+        testBill.setPaymentStatus(PaymentStatus.PENDING);
+        testBill.setPaymentMethod(PaymentMethod.CASH);
+        testBill.setNotes("Update test bill " + System.currentTimeMillis());
+
+        assertTrue(billDAO.createBill(testBill), "Should create test bill");
+
+        List<Bill> bills = billDAO.getAllBills();
+        Bill createdBill = bills.stream()
+                .filter(b -> testBill.getNotes().equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        BigDecimal newTotal = new BigDecimal("450.00");
+        String newNotes = "Updated bill notes " + System.currentTimeMillis();
+        createdBill.setTotalAmount(newTotal);
+        createdBill.setPaymentStatus(PaymentStatus.PAID);
+        createdBill.setNotes(newNotes);
+
+        boolean updated = billDAO.updateBill(createdBill);
+        assertTrue(updated, "Should successfully update bill");
+
+        Bill updatedBill = billDAO.getBillById(createdBill.getBillId());
+        assertNotNull(updatedBill, "Should still find the updated bill");
+        assertEquals(newTotal, updatedBill.getTotalAmount(), "Total amount should be updated");
+        assertEquals(PaymentStatus.PAID, updatedBill.getPaymentStatus(), "Payment status should be updated");
+        assertEquals(newNotes, updatedBill.getNotes(), "Notes should be updated");
+    }
+
+    @Test
+    void shouldDeleteBill() {
+
+        Bill billToDelete = new Bill();
+        billToDelete.setCustomerId(1);
+        billToDelete.setUserId(1);
+        billToDelete.setTotalAmount(new BigDecimal("100.00"));
+        billToDelete.setPaymentStatus(PaymentStatus.PENDING);
+        billToDelete.setPaymentMethod(PaymentMethod.CASH);
+        billToDelete.setNotes("Temp delete bill " + System.currentTimeMillis());
+
+        boolean created = billDAO.createBill(billToDelete);
+        assertTrue(created, "Should create temporary bill");
+
+        List<Bill> bills = billDAO.getAllBills();
+        Bill createdBill = bills.stream()
+                .filter(b -> billToDelete.getNotes().equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        boolean deleted = billDAO.deleteBill(createdBill.getBillId());
+        assertTrue(deleted, "Should successfully delete bill");
+
+        Bill deletedBill = billDAO.getBillById(createdBill.getBillId());
+        assertNull(deletedBill, "Deleted bill should not be retrievable");
+    }
+
+    @Test
+    void shouldGetBillsByCustomer() {
+
+        List<Bill> customerBills = billDAO.getBillsByCustomer(1);
+
+        assertNotNull(customerBills, "Customer bills list should not be null");
+        assertFalse(customerBills.isEmpty(), "Customer 1 should have bills from seed data");
+
+        for (Bill bill : customerBills) {
+            assertEquals(1, bill.getCustomerId(), "All bills should belong to customer 1");
+            assertNotNull(bill.getCustomer(), "Bill should have customer object populated");
+            assertEquals("John Doe", bill.getCustomer().getName(), "Customer name should match focused test data");
+        }
+    }
+
+    @Test
+    void shouldUpdatePaymentStatus() {
+
+        Bill testBill = new Bill();
+        testBill.setCustomerId(1);
+        testBill.setUserId(1);
+        testBill.setTotalAmount(new BigDecimal("200.00"));
+        testBill.setPaymentStatus(PaymentStatus.PENDING);
+        testBill.setPaymentMethod(PaymentMethod.CASH);
+        testBill.setNotes("Payment status test bill " + System.currentTimeMillis());
+
+        assertTrue(billDAO.createBill(testBill), "Should create test bill");
+
+        List<Bill> bills = billDAO.getAllBills();
+        Bill createdBill = bills.stream()
+                .filter(b -> testBill.getNotes().equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        boolean updated = billDAO.updatePaymentStatus(createdBill.getBillId(), PaymentStatus.PAID);
+        assertTrue(updated, "Should successfully update payment status");
+
+        Bill updatedBill = billDAO.getBillById(createdBill.getBillId());
+        assertNotNull(updatedBill, "Should still find the updated bill");
+        assertEquals(PaymentStatus.PAID, updatedBill.getPaymentStatus(), "Payment status should be updated to PAID");
+    }
+
+    @Test
+    void shouldCalculateTotalAmount() {
+
+        BigDecimal calculatedTotal = billDAO.calculateTotalAmount(1);
+
+        assertNotNull(calculatedTotal, "Calculated total should not be null");
+        assertTrue(calculatedTotal.compareTo(BigDecimal.ZERO) > 0, "Calculated total should be positive");
+
+        assertEquals(new BigDecimal("1700.00"), calculatedTotal, "Calculated total should match sum of line items");
+    }
+
+    @Test
+    void shouldHandleNullAndInvalidInputs() {
+
+        assertFalse(billDAO.createBill(null), "Creating null bill should return false");
+        assertFalse(billDAO.updateBill(null), "Updating null bill should return false");
+        assertFalse(billDAO.deleteBill(-1), "Deleting with negative ID should return false");
+
+        List<Bill> invalidCustomerBills = billDAO.getBillsByCustomer(99999);
+
+        assertNotNull(invalidCustomerBills, "Should return empty list for invalid customer");
+        assertTrue(invalidCustomerBills.isEmpty(), "Should return empty list for invalid customer");
+
+        assertFalse(billDAO.updatePaymentStatus(99999, PaymentStatus.PAID), "Invalid bill ID should return false");
+
+        BigDecimal invalidTotal = billDAO.calculateTotalAmount(99999);
+        assertEquals(BigDecimal.ZERO, invalidTotal, "Invalid bill should return zero total");
+    }
+
+    @Test
+    void shouldValidateBillCreationRequirements() {
+
+        Bill invalidBill = new Bill();
+
+        invalidBill.setUserId(1);
+        invalidBill.setTotalAmount(new BigDecimal("100.00"));
+        invalidBill.setPaymentStatus(PaymentStatus.PENDING);
+        invalidBill.setPaymentMethod(PaymentMethod.CASH);
+
+        assertFalse(billDAO.createBill(invalidBill), "Bill without customer should fail to create");
+
+        Bill billWithoutUser = new Bill();
+        billWithoutUser.setCustomerId(1);
+        billWithoutUser.setTotalAmount(new BigDecimal("100.00"));
+        billWithoutUser.setPaymentStatus(PaymentStatus.PENDING);
+        billWithoutUser.setPaymentMethod(PaymentMethod.CASH);
+
+        assertFalse(billDAO.createBill(billWithoutUser), "Bill without user should fail to create");
+    }
+
+    @Test
+    void shouldLoadBillWithItems() {
+
+        Bill billWithItems = billDAO.getBillById(1);
+
+        assertNotNull(billWithItems, "Should find bill with ID 1");
+
+        if (billWithItems.getBillItems() != null) {
+            assertFalse(billWithItems.getBillItems().isEmpty(), "Bill should have bill items");
+
+            for (BillItem item : billWithItems.getBillItems()) {
+                assertNotNull(item.getItem(), "Bill item should have item object");
+                assertNotNull(item.getItem().getName(), "Item should have name");
+                assertTrue(item.getQuantity() > 0, "Quantity should be positive");
+                assertTrue(item.getUnitPrice().compareTo(BigDecimal.ZERO) > 0, "Unit price should be positive");
+                assertTrue(item.getLineTotal().compareTo(BigDecimal.ZERO) > 0, "Line total should be positive");
+            }
+        }
+    }
+}

--- a/src/test/java/com/pahanaedu/dao/BillItemDAOTest.java
+++ b/src/test/java/com/pahanaedu/dao/BillItemDAOTest.java
@@ -1,0 +1,354 @@
+package com.pahanaedu.dao;
+
+import com.pahanaedu.helpers.DatabaseHelper;
+import com.pahanaedu.model.BillItem;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BillItemDAOTest {
+
+    private BillItemDAO billItemDAO;
+
+    @BeforeAll
+    static void setupDatabase() throws SQLException {
+
+        try (Connection connection = DatabaseHelper.getInstance().getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+            statement.execute("DELETE FROM bill_items");
+            statement.execute("DELETE FROM bills");
+            statement.execute("DELETE FROM items");
+            statement.execute("DELETE FROM categories");
+            statement.execute("DELETE FROM customers");
+            statement.execute("DELETE FROM users");
+            statement.execute("ALTER TABLE bill_items AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE bills AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE items AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE categories AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE customers AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE users AUTO_INCREMENT = 1");
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+            statement.execute(
+                    "INSERT INTO users (user_id, email, password, first_name, last_name, role, created_at, updated_at) VALUES "
+                            +
+                            "(1, 'admin@pahanaedu.com', 'admin123', 'Admin', 'User', 'ADMIN', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO customers (customer_id, account_number, name, address, telephone, email, created_at, updated_at) VALUES "
+                            +
+                            "(1, 000001, 'John Doe', '123 Main St, Colombo', '0771234567', 'john.doe@email.com', NOW(), NOW())");
+
+            statement
+                    .execute("INSERT INTO categories (category_id, name, description, created_at, updated_at) VALUES " +
+                            "(1, 'Books', 'Educational books and textbooks', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO items (item_id, name, description, category_id, unit_price, created_at, updated_at) VALUES "
+                            +
+                            "(1, 'Mathematics Textbook', 'Grade 10 Mathematics textbook', 1, 1500.00, NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO bills (bill_id, customer_id, user_id, total_amount, payment_status, payment_method, notes, created_at, updated_at) VALUES "
+                            +
+                            "(1, 1, 1, 1700.00, 'PAID', 'CASH', 'Test bill', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO bill_items (bill_item_id, bill_id, item_id, quantity, unit_price, line_total, created_at, updated_at) VALUES "
+                            +
+                            "(1, 1, 1, 2, 850.00, 1700.00, NOW(), NOW())");
+
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        billItemDAO = new BillItemDAO();
+    }
+
+    @Test
+    void shouldRetrieveBillItemsByBillId() {
+
+        List<BillItem> billItems = billItemDAO.getBillItemsByBillId(1);
+
+        assertNotNull(billItems, "Bill items list should not be null");
+        assertFalse(billItems.isEmpty(), "Bill 1 should have items from seed data");
+
+        BillItem firstItem = billItems.get(0);
+        assertNotNull(firstItem.getItem(), "Bill item should have item populated");
+        assertNotNull(firstItem.getItem().getName(), "Item should have name");
+        assertTrue(firstItem.getQuantity() > 0, "Quantity should be positive");
+        assertTrue(firstItem.getUnitPrice().compareTo(BigDecimal.ZERO) > 0, "Unit price should be positive");
+        assertTrue(firstItem.getLineTotal().compareTo(BigDecimal.ZERO) > 0, "Line total should be positive");
+    }
+
+    @Test
+    void shouldReturnEmptyListForBillWithNoItems() {
+
+        List<BillItem> billItems = billItemDAO.getBillItemsByBillId(99999);
+
+        assertNotNull(billItems, "Bill items list should not be null");
+        assertTrue(billItems.isEmpty(), "Non-existent bill should have no items");
+    }
+
+    @Test
+    void shouldRetrieveBillItemById() {
+
+        BillItem billItem = billItemDAO.getBillItemById(1);
+
+        assertNotNull(billItem, "Should find bill item with ID 1");
+        assertEquals(1, billItem.getBillId(), "Bill item should belong to bill 1");
+        assertEquals(1, billItem.getItemId(), "Bill item should reference item 1");
+        assertEquals(2, billItem.getQuantity(), "Quantity should match seed data");
+        assertEquals(new BigDecimal("850.00"), billItem.getUnitPrice(), "Unit price should match seed data");
+        assertEquals(new BigDecimal("1700.00"), billItem.getLineTotal(), "Line total should match seed data");
+
+        assertNotNull(billItem.getItem(), "Bill item should have item populated");
+        assertEquals("Mathematics Textbook", billItem.getItem().getName(), "Item name should match");
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentBillItem() {
+
+        BillItem result = billItemDAO.getBillItemById(99999);
+        assertNull(result, "Non-existent bill item should return null");
+    }
+
+    @Test
+    void shouldCreateNewBillItem() {
+
+        BillDAO billDAO = new BillDAO();
+        com.pahanaedu.model.Bill testBill = new com.pahanaedu.model.Bill();
+        testBill.setCustomerId(1);
+        testBill.setUserId(1);
+        testBill.setTotalAmount(new BigDecimal("500.00"));
+        testBill.setPaymentStatus(com.pahanaedu.enums.PaymentStatus.PENDING);
+        testBill.setPaymentMethod(com.pahanaedu.enums.PaymentMethod.CASH);
+        testBill.setNotes("Test bill for item creation");
+
+        assertTrue(billDAO.createBill(testBill), "Should create test bill");
+
+        List<com.pahanaedu.model.Bill> bills = billDAO.getAllBills();
+        com.pahanaedu.model.Bill createdBill = bills.stream()
+                .filter(b -> "Test bill for item creation".equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        BillItem newBillItem = new BillItem();
+        newBillItem.setBillId(createdBill.getBillId());
+        newBillItem.setItemId(1);
+        newBillItem.setQuantity(3);
+        newBillItem.setUnitPrice(new BigDecimal("100.00"));
+        newBillItem.setLineTotal(new BigDecimal("300.00"));
+
+        boolean created = billItemDAO.createBillItem(newBillItem);
+        assertTrue(created, "Should successfully create new bill item");
+
+        List<BillItem> billItems = billItemDAO.getBillItemsByBillId(createdBill.getBillId());
+        assertFalse(billItems.isEmpty(), "Bill should have the new item");
+
+        BillItem foundItem = billItems.get(0);
+        assertEquals(3, foundItem.getQuantity(), "Quantity should match");
+        assertEquals(new BigDecimal("100.00"), foundItem.getUnitPrice(), "Unit price should match");
+        assertEquals(new BigDecimal("300.00"), foundItem.getLineTotal(), "Line total should match");
+    }
+
+    @Test
+    void shouldUpdateExistingBillItem() {
+
+        BillDAO billDAO = new BillDAO();
+        com.pahanaedu.model.Bill testBill = new com.pahanaedu.model.Bill();
+        testBill.setCustomerId(1);
+        testBill.setUserId(1);
+        testBill.setTotalAmount(new BigDecimal("400.00"));
+        testBill.setPaymentStatus(com.pahanaedu.enums.PaymentStatus.PENDING);
+        testBill.setPaymentMethod(com.pahanaedu.enums.PaymentMethod.CASH);
+        testBill.setNotes("Test bill for item update");
+
+        assertTrue(billDAO.createBill(testBill), "Should create test bill");
+
+        List<com.pahanaedu.model.Bill> bills = billDAO.getAllBills();
+        com.pahanaedu.model.Bill createdBill = bills.stream()
+                .filter(b -> "Test bill for item update".equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        BillItem billItem = new BillItem();
+        billItem.setBillId(createdBill.getBillId());
+        billItem.setItemId(1);
+        billItem.setQuantity(2);
+        billItem.setUnitPrice(new BigDecimal("200.00"));
+        billItem.setLineTotal(new BigDecimal("400.00"));
+
+        assertTrue(billItemDAO.createBillItem(billItem), "Should create bill item");
+
+        List<BillItem> billItems = billItemDAO.getBillItemsByBillId(createdBill.getBillId());
+        BillItem createdBillItem = billItems.get(0);
+
+        createdBillItem.setQuantity(5);
+        createdBillItem.setUnitPrice(new BigDecimal("150.00"));
+        createdBillItem.setLineTotal(new BigDecimal("750.00"));
+
+        boolean updated = billItemDAO.updateBillItem(createdBillItem);
+        assertTrue(updated, "Should successfully update bill item");
+
+        BillItem updatedBillItem = billItemDAO.getBillItemById(createdBillItem.getBillItemId());
+        assertNotNull(updatedBillItem, "Should find the updated bill item");
+        assertEquals(5, updatedBillItem.getQuantity(), "Quantity should be updated");
+        assertEquals(new BigDecimal("150.00"), updatedBillItem.getUnitPrice(), "Unit price should be updated");
+        assertEquals(new BigDecimal("750.00"), updatedBillItem.getLineTotal(), "Line total should be updated");
+    }
+
+    @Test
+    void shouldDeleteBillItem() {
+
+        BillDAO billDAO = new BillDAO();
+        com.pahanaedu.model.Bill testBill = new com.pahanaedu.model.Bill();
+        testBill.setCustomerId(1);
+        testBill.setUserId(1);
+        testBill.setTotalAmount(new BigDecimal("100.00"));
+        testBill.setPaymentStatus(com.pahanaedu.enums.PaymentStatus.PENDING);
+        testBill.setPaymentMethod(com.pahanaedu.enums.PaymentMethod.CASH);
+        testBill.setNotes("Test bill for item deletion");
+
+        assertTrue(billDAO.createBill(testBill), "Should create test bill");
+
+        List<com.pahanaedu.model.Bill> bills = billDAO.getAllBills();
+        com.pahanaedu.model.Bill createdBill = bills.stream()
+                .filter(b -> "Test bill for item deletion".equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        BillItem billItem = new BillItem();
+        billItem.setBillId(createdBill.getBillId());
+        billItem.setItemId(1);
+        billItem.setQuantity(1);
+        billItem.setUnitPrice(new BigDecimal("100.00"));
+        billItem.setLineTotal(new BigDecimal("100.00"));
+
+        assertTrue(billItemDAO.createBillItem(billItem), "Should create bill item");
+
+        List<BillItem> billItems = billItemDAO.getBillItemsByBillId(createdBill.getBillId());
+        BillItem createdBillItem = billItems.get(0);
+
+        boolean deleted = billItemDAO.deleteBillItem(createdBillItem.getBillItemId());
+        assertTrue(deleted, "Should successfully delete bill item");
+
+        BillItem deletedBillItem = billItemDAO.getBillItemById(createdBillItem.getBillItemId());
+        assertNull(deletedBillItem, "Deleted bill item should not be retrievable");
+    }
+
+    @Test
+    void shouldDeleteAllBillItemsByBillId() {
+
+        BillDAO billDAO = new BillDAO();
+        com.pahanaedu.model.Bill testBill = new com.pahanaedu.model.Bill();
+        testBill.setCustomerId(1);
+        testBill.setUserId(1);
+        testBill.setTotalAmount(new BigDecimal("500.00"));
+        testBill.setPaymentStatus(com.pahanaedu.enums.PaymentStatus.PENDING);
+        testBill.setPaymentMethod(com.pahanaedu.enums.PaymentMethod.CASH);
+        testBill.setNotes("Test bill for bulk item deletion");
+
+        assertTrue(billDAO.createBill(testBill), "Should create test bill");
+
+        List<com.pahanaedu.model.Bill> bills = billDAO.getAllBills();
+        com.pahanaedu.model.Bill createdBill = bills.stream()
+                .filter(b -> "Test bill for bulk item deletion".equals(b.getNotes()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdBill, "Should find the created bill");
+
+        BillItem item1 = new BillItem();
+        item1.setBillId(createdBill.getBillId());
+        item1.setItemId(1);
+        item1.setQuantity(1);
+        item1.setUnitPrice(new BigDecimal("100.00"));
+        item1.setLineTotal(new BigDecimal("100.00"));
+
+        BillItem item2 = new BillItem();
+        item2.setBillId(createdBill.getBillId());
+        item2.setItemId(1);
+        item2.setQuantity(2);
+        item2.setUnitPrice(new BigDecimal("200.00"));
+        item2.setLineTotal(new BigDecimal("400.00"));
+
+        assertTrue(billItemDAO.createBillItem(item1), "Should create first bill item");
+        assertTrue(billItemDAO.createBillItem(item2), "Should create second bill item");
+
+        List<BillItem> billItems = billItemDAO.getBillItemsByBillId(createdBill.getBillId());
+        assertEquals(2, billItems.size(), "Should have 2 bill items");
+
+        boolean deleted = billItemDAO.deleteBillItemsByBillId(createdBill.getBillId());
+        assertTrue(deleted, "Should successfully delete all bill items");
+
+        List<BillItem> remainingItems = billItemDAO.getBillItemsByBillId(createdBill.getBillId());
+        assertTrue(remainingItems.isEmpty(), "Should have no remaining items");
+    }
+
+    @Test
+    void shouldHandleNullAndInvalidInputs() {
+
+        assertFalse(billItemDAO.createBillItem(null), "Creating null bill item should return false");
+        assertFalse(billItemDAO.updateBillItem(null), "Updating null bill item should return false");
+        assertFalse(billItemDAO.deleteBillItem(-1), "Deleting with negative ID should return false");
+        assertFalse(billItemDAO.deleteBillItemsByBillId(-1),
+                "Deleting items with negative bill ID should return false");
+
+        List<BillItem> invalidBillItems = billItemDAO.getBillItemsByBillId(99999);
+        assertNotNull(invalidBillItems, "Should return empty list for invalid bill");
+        assertTrue(invalidBillItems.isEmpty(), "Should return empty list for invalid bill");
+    }
+
+    @Test
+    void shouldValidateBillItemCreationRequirements() {
+
+        BillItem invalidBillItem = new BillItem();
+
+        invalidBillItem.setItemId(1);
+        invalidBillItem.setQuantity(1);
+        invalidBillItem.setUnitPrice(new BigDecimal("100.00"));
+        invalidBillItem.setLineTotal(new BigDecimal("100.00"));
+
+        assertFalse(billItemDAO.createBillItem(invalidBillItem), "Bill item without bill ID should fail to create");
+
+        BillItem billItemWithInvalidBill = new BillItem();
+        billItemWithInvalidBill.setBillId(999);
+        billItemWithInvalidBill.setItemId(1);
+        billItemWithInvalidBill.setQuantity(1);
+        billItemWithInvalidBill.setUnitPrice(new BigDecimal("100.00"));
+        billItemWithInvalidBill.setLineTotal(new BigDecimal("100.00"));
+
+        assertFalse(billItemDAO.createBillItem(billItemWithInvalidBill),
+                "Bill item with non-existent bill ID should fail to create");
+
+        BillItem billItemWithInvalidItem = new BillItem();
+        billItemWithInvalidItem.setBillId(1);
+        billItemWithInvalidItem.setItemId(999);
+        billItemWithInvalidItem.setQuantity(1);
+        billItemWithInvalidItem.setUnitPrice(new BigDecimal("100.00"));
+        billItemWithInvalidItem.setLineTotal(new BigDecimal("100.00"));
+
+        assertFalse(billItemDAO.createBillItem(billItemWithInvalidItem),
+                "Bill item with non-existent item ID should fail to create");
+    }
+}

--- a/src/test/java/com/pahanaedu/dao/CategoryDAOTest.java
+++ b/src/test/java/com/pahanaedu/dao/CategoryDAOTest.java
@@ -1,0 +1,194 @@
+package com.pahanaedu.dao;
+
+import com.pahanaedu.helpers.DatabaseHelper;
+import com.pahanaedu.model.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CategoryDAOTest {
+
+    private CategoryDAO categoryDAO;
+
+    @BeforeAll
+    static void setupDatabase() throws SQLException {
+        
+
+        try (Connection connection = DatabaseHelper.getInstance().getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+            statement.execute("DELETE FROM categories");
+            statement.execute("ALTER TABLE categories AUTO_INCREMENT = 1");
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+            statement
+                    .execute("INSERT INTO categories (category_id, name, description, created_at, updated_at) VALUES " +
+                            "(1, 'Books', 'Educational books and textbooks', NOW(), NOW()), " +
+                            "(2, 'Stationery', 'School and office supplies', NOW(), NOW())");
+
+            
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        categoryDAO = new CategoryDAO();
+    }
+
+    @Test
+    void shouldRetrieveExistingCategories() {
+
+        List<Category> categories = categoryDAO.getAllCategories();
+
+        assertNotNull(categories, "Categories list should not be null");
+        assertFalse(categories.isEmpty(), "Should have categories from test data");
+
+        assertEquals(2, categories.size(), "Should have exactly 2 test categories");
+
+        boolean hasBooks = categories.stream().anyMatch(c -> "Books".equals(c.getName()));
+        boolean hasStationery = categories.stream().anyMatch(c -> "Stationery".equals(c.getName()));
+
+        assertTrue(hasBooks, "Should have 'Books' category from test data");
+        assertTrue(hasStationery, "Should have 'Stationery' category from test data");
+    }
+
+    @Test
+    void shouldRetrieveCategoryById() {
+
+        Category category = categoryDAO.getCategoryById(1);
+
+        assertNotNull(category, "Should find category with ID 1");
+        assertEquals("Books", category.getName(), "Category ID 1 should be 'Books'");
+        assertEquals("Educational books and textbooks", category.getDescription());
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentCategory() {
+
+        Category result = categoryDAO.getCategoryById(99999);
+        assertNull(result, "Non-existent category should return null");
+    }
+
+    @Test
+    void shouldHandleInvalidIds() {
+
+        assertNull(categoryDAO.getCategoryById(-1), "Negative ID should return null");
+        assertNull(categoryDAO.getCategoryById(0), "Zero ID should return null");
+    }
+
+    @Test
+    void shouldCreateNewCategory() {
+
+        Category newCategory = new Category();
+        newCategory.setName("Test Category " + System.currentTimeMillis());
+        newCategory.setDescription("Test description");
+
+        boolean created = categoryDAO.createCategory(newCategory);
+        assertTrue(created, "Should successfully create new category");
+
+        List<Category> categories = categoryDAO.getAllCategories();
+        boolean found = categories.stream()
+                .anyMatch(c -> newCategory.getName().equals(c.getName()));
+        assertTrue(found, "New category should appear in categories list");
+    }
+
+    @Test
+    void shouldUpdateExistingCategory() {
+
+        Category testCategory = new Category();
+        testCategory.setName("Update Test Category " + System.currentTimeMillis());
+        testCategory.setDescription("Original description");
+
+        assertTrue(categoryDAO.createCategory(testCategory), "Should create test category");
+
+        List<Category> categories = categoryDAO.getAllCategories();
+        Category createdCategory = categories.stream()
+                .filter(c -> testCategory.getName().equals(c.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdCategory, "Should find the created category");
+
+        String newDescription = "Updated description " + System.currentTimeMillis();
+        createdCategory.setDescription(newDescription);
+
+        boolean updated = categoryDAO.updateCategory(createdCategory);
+        assertTrue(updated, "Should successfully update category");
+
+        Category updatedCategory = categoryDAO.getCategoryById(createdCategory.getCategoryId());
+        assertNotNull(updatedCategory, "Should still find the updated category");
+        assertEquals(newDescription, updatedCategory.getDescription(), "Description should be updated");
+    }
+
+    @Test
+    void shouldDeleteCategory() {
+
+        Category categoryToDelete = new Category();
+        categoryToDelete.setName("Temp Delete Category " + System.currentTimeMillis());
+        categoryToDelete.setDescription("Temporary category for deletion test");
+
+        boolean created = categoryDAO.createCategory(categoryToDelete);
+        assertTrue(created, "Should create temporary category");
+
+        List<Category> categories = categoryDAO.getAllCategories();
+        Category createdCategory = categories.stream()
+                .filter(c -> categoryToDelete.getName().equals(c.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdCategory, "Should find the created category");
+
+        boolean deleted = categoryDAO.deleteCategory(createdCategory.getCategoryId());
+        assertTrue(deleted, "Should successfully delete category");
+
+        Category deletedCategory = categoryDAO.getCategoryById(createdCategory.getCategoryId());
+        assertNull(deletedCategory, "Deleted category should not be retrievable");
+    }
+
+    @Test
+    void shouldCheckCategoryNameExists() {
+
+        assertTrue(categoryDAO.isCategoryNameExists("Books"), "Should find existing 'Books' category");
+        assertFalse(categoryDAO.isCategoryNameExists("NonExistentCategory"), "Should not find non-existent category");
+    }
+
+    @Test
+    void shouldGetAllCategoryNames() {
+
+        List<String> names = categoryDAO.getAllCategoryNames();
+
+        assertNotNull(names, "Category names list should not be null");
+        assertFalse(names.isEmpty(), "Should have category names from seed data");
+        assertTrue(names.contains("Books"), "Should contain 'Books' from seed data");
+        assertTrue(names.contains("Stationery"), "Should contain 'Stationery' from seed data");
+    }
+
+    @Test
+    void shouldCheckDependentItems() {
+
+        boolean hasItems = categoryDAO.hasDependentItems(1);
+        assertTrue(hasItems, "Books category should have dependent items from seed data");
+
+        assertFalse(categoryDAO.hasDependentItems(99999), "Non-existent category should not have items");
+    }
+
+    @Test
+    void shouldHandleNullAndInvalidInputs() {
+
+        assertFalse(categoryDAO.createCategory(null), "Creating null category should return false");
+        assertFalse(categoryDAO.updateCategory(null), "Updating null category should return false");
+        assertFalse(categoryDAO.deleteCategory(-1), "Deleting with negative ID should return false");
+        assertFalse(categoryDAO.isCategoryNameExists(null), "Checking null name should return false");
+        assertFalse(categoryDAO.isCategoryNameExists(""), "Checking empty name should return false");
+    }
+}

--- a/src/test/java/com/pahanaedu/dao/CustomerDAOTest.java
+++ b/src/test/java/com/pahanaedu/dao/CustomerDAOTest.java
@@ -1,0 +1,244 @@
+package com.pahanaedu.dao;
+
+import com.pahanaedu.helpers.DatabaseHelper;
+import com.pahanaedu.model.Customer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomerDAOTest {
+
+    private CustomerDAO customerDAO;
+
+    @BeforeAll
+    static void setupDatabase() throws SQLException {
+        
+
+        try (Connection connection = DatabaseHelper.getInstance().getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+            statement.execute("DELETE FROM customers");
+            statement.execute("ALTER TABLE customers AUTO_INCREMENT = 1");
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+            statement.execute(
+                    "INSERT INTO customers (customer_id, account_number, name, address, telephone, email, created_at, updated_at) VALUES "
+                            +
+                            "(1, 000001, 'John Doe', '123 Main St, Colombo', '0771234567', 'john.doe@email.com', NOW(), NOW()), "
+                            +
+                            "(2, 000002, 'Jane Smith', '456 Queen St, Kandy', '0779876543', 'jane.smith@email.com', NOW(), NOW())");
+
+            
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        customerDAO = new CustomerDAO();
+    }
+
+    @Test
+    void shouldRetrieveExistingCustomers() {
+
+        List<Customer> customers = customerDAO.getAllCustomers();
+
+        assertNotNull(customers, "Customers list should not be null");
+        assertFalse(customers.isEmpty(), "Should have customers from seed data");
+
+        assertTrue(customers.size() == 2, "Should have  2 seed customers");
+
+        boolean hasJohnDoe = customers.stream().anyMatch(c -> "John Doe".equals(c.getName()));
+        boolean hasJaneSmith = customers.stream().anyMatch(c -> "Jane Smith".equals(c.getName()));
+
+        assertTrue(hasJohnDoe, "Should have 'John Doe' from focused test data");
+        assertTrue(hasJaneSmith, "Should have 'Jane Smith' from focused test data");
+    }
+
+    @Test
+    void shouldRetrieveCustomerById() {
+
+        List<Customer> customers = customerDAO.getAllCustomers();
+        assertFalse(customers.isEmpty(), "Should have customers to test with");
+
+        Customer firstCustomer = customers.get(0);
+        Customer retrievedCustomer = customerDAO.getCustomerById(firstCustomer.getCustomerId());
+
+        assertNotNull(retrievedCustomer, "Should find customer by valid ID");
+        assertEquals(firstCustomer.getName(), retrievedCustomer.getName(), "Retrieved customer should match");
+        assertEquals(firstCustomer.getAccountNumber(), retrievedCustomer.getAccountNumber(),
+                "Account numbers should match");
+    }
+
+    @Test
+    void shouldRetrieveCustomerByAccountNumber() {
+
+        Customer customer = customerDAO.getCustomerByAccountNumber("1");
+
+        assertNotNull(customer, "Should find customer with account number 1");
+        assertEquals("John Doe", customer.getName(), "Should be John Doe from focused test data");
+        assertEquals("123 Main St, Colombo", customer.getAddress(), "Address should match focused test data");
+        assertEquals("0771234567", customer.getTelephone(), "Telephone should match focused test data");
+    }
+
+    @Test
+    void shouldCreateNewCustomer() {
+
+        Customer newCustomer = new Customer();
+        newCustomer.setName("Test School " + System.currentTimeMillis());
+        newCustomer.setAddress("Test Address");
+        newCustomer.setTelephone("+94-11-9999999");
+        newCustomer.setEmail("test" + System.currentTimeMillis() + "@school.lk");
+
+        String accountNumber = customerDAO.generateAccountNumber();
+        newCustomer.setAccountNumber(accountNumber);
+
+        boolean created = customerDAO.createCustomer(newCustomer);
+        assertTrue(created, "Should successfully create new customer");
+
+        List<Customer> customers = customerDAO.getAllCustomers();
+        boolean found = customers.stream()
+                .anyMatch(c -> newCustomer.getName().equals(c.getName()));
+        assertTrue(found, "New customer should appear in customers list");
+    }
+
+    @Test
+    void shouldUpdateExistingCustomer() {
+
+        Customer testCustomer = new Customer();
+        testCustomer.setName("Update Test School " + System.currentTimeMillis());
+        testCustomer.setAddress("Original Address");
+        testCustomer.setTelephone("+94-11-1111111");
+        testCustomer.setEmail("original" + System.currentTimeMillis() + "@school.lk");
+
+        String accountNumber = customerDAO.generateAccountNumber();
+        testCustomer.setAccountNumber(accountNumber);
+
+        assertTrue(customerDAO.createCustomer(testCustomer), "Should create test customer");
+
+        List<Customer> customers = customerDAO.getAllCustomers();
+        Customer createdCustomer = customers.stream()
+                .filter(c -> testCustomer.getName().equals(c.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdCustomer, "Should find the created customer");
+
+        String newAddress = "Updated Address " + System.currentTimeMillis();
+        String newTelephone = "+94-11-2222222";
+        createdCustomer.setAddress(newAddress);
+        createdCustomer.setTelephone(newTelephone);
+
+        boolean updated = customerDAO.updateCustomer(createdCustomer);
+        assertTrue(updated, "Should successfully update customer");
+
+        Customer updatedCustomer = customerDAO.getCustomerById(createdCustomer.getCustomerId());
+        assertNotNull(updatedCustomer, "Should still find the updated customer");
+        assertEquals(newAddress, updatedCustomer.getAddress(), "Address should be updated");
+        assertEquals(newTelephone, updatedCustomer.getTelephone(), "Telephone should be updated");
+    }
+
+    @Test
+    void shouldDeleteCustomer() {
+
+        Customer customerToDelete = new Customer();
+        customerToDelete.setName("Temp Delete School " + System.currentTimeMillis());
+        customerToDelete.setAddress("Temporary address");
+        customerToDelete.setTelephone("+94-11-0000000");
+        customerToDelete.setEmail("delete" + System.currentTimeMillis() + "@school.lk");
+
+        String accountNumber = customerDAO.generateAccountNumber();
+        customerToDelete.setAccountNumber(accountNumber);
+
+        boolean created = customerDAO.createCustomer(customerToDelete);
+        assertTrue(created, "Should create temporary customer");
+
+        List<Customer> customers = customerDAO.getAllCustomers();
+        Customer createdCustomer = customers.stream()
+                .filter(c -> customerToDelete.getName().equals(c.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdCustomer, "Should find the created customer");
+
+        boolean deleted = customerDAO.deleteCustomer(createdCustomer.getCustomerId());
+        assertTrue(deleted, "Should successfully delete customer");
+
+        Customer deletedCustomer = customerDAO.getCustomerById(createdCustomer.getCustomerId());
+        assertNull(deletedCustomer, "Deleted customer should not be retrievable");
+    }
+
+    @Test
+    void shouldGenerateAccountNumber() {
+
+        String accountNumber = customerDAO.generateAccountNumber();
+
+        assertNotNull(accountNumber, "Generated account number should not be null");
+        assertFalse(accountNumber.isEmpty(), "Generated account number should not be empty");
+        assertTrue(accountNumber.matches("\\d+"), "Account number should be digits");
+
+        String anotherAccountNumber = customerDAO.generateAccountNumber();
+        assertEquals(accountNumber, anotherAccountNumber, "Generated account numbers should be the same");
+    }
+
+    @Test
+    void shouldCheckAccountNumberExists() {
+
+        assertTrue(customerDAO.isAccountNumberExists("1"), "Should find existing account number 1");
+        assertTrue(customerDAO.isAccountNumberExists("2"), "Should find existing account number 2");
+        assertFalse(customerDAO.isAccountNumberExists("999"), "Should not find non-existent account number");
+    }
+
+    @Test
+    void shouldCheckAccountNumberExistsForUpdate() {
+
+        List<Customer> customers = customerDAO.getAllCustomers();
+        assertFalse(customers.isEmpty(), "Should have customers to test with");
+
+        Customer firstCustomer = customers.get(0);
+
+        assertFalse(
+                customerDAO.isAccountNumberExistsForUpdate(firstCustomer.getAccountNumber(),
+                        firstCustomer.getCustomerId()),
+                "Same customer's account number should not be considered duplicate for update");
+
+        if (customers.size() > 1) {
+            Customer secondCustomer = customers.get(1);
+            assertTrue(
+                    customerDAO.isAccountNumberExistsForUpdate(secondCustomer.getAccountNumber(),
+                            firstCustomer.getCustomerId()),
+                    "Different customer's account number should be considered duplicate for update");
+        }
+    }
+
+    @Test
+    void shouldReturnNullForInvalidInputs() {
+
+        assertNull(customerDAO.getCustomerById(-1), "Negative ID should return null");
+        assertNull(customerDAO.getCustomerById(0), "Zero ID should return null");
+        assertNull(customerDAO.getCustomerById(99999), "Non-existent ID should return null");
+        assertNull(customerDAO.getCustomerByAccountNumber(null), "Null account number should return null");
+        assertNull(customerDAO.getCustomerByAccountNumber(""), "Empty account number should return null");
+        assertNull(customerDAO.getCustomerByAccountNumber("999"), "Non-existent account number should return null");
+    }
+
+    @Test
+    void shouldHandleInvalidOperations() {
+
+        assertFalse(customerDAO.createCustomer(null), "Creating null customer should return false");
+        assertFalse(customerDAO.updateCustomer(null), "Updating null customer should return false");
+        assertFalse(customerDAO.deleteCustomer(-1), "Deleting with negative ID should return false");
+        assertFalse(customerDAO.deleteCustomer(0), "Deleting with zero ID should return false");
+        assertFalse(customerDAO.isAccountNumberExists(null), "Checking null account number should return false");
+        assertFalse(customerDAO.isAccountNumberExists(""), "Checking empty account number should return false");
+    }
+}

--- a/src/test/java/com/pahanaedu/dao/ItemDAOTest.java
+++ b/src/test/java/com/pahanaedu/dao/ItemDAOTest.java
@@ -1,0 +1,259 @@
+package com.pahanaedu.dao;
+
+import com.pahanaedu.helpers.DatabaseHelper;
+import com.pahanaedu.model.Item;
+import com.pahanaedu.model.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ItemDAOTest {
+
+    private ItemDAO itemDAO;
+
+    @BeforeAll
+    static void setupDatabase() throws SQLException {
+
+        try (Connection connection = DatabaseHelper.getInstance().getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+            statement.execute("DELETE FROM items");
+            statement.execute("DELETE FROM categories");
+            statement.execute("ALTER TABLE items AUTO_INCREMENT = 1");
+            statement.execute("ALTER TABLE categories AUTO_INCREMENT = 1");
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+            statement
+                    .execute("INSERT INTO categories (category_id, name, description, created_at, updated_at) VALUES " +
+                            "(1, 'Books', 'Educational books and textbooks', NOW(), NOW()), " +
+                            "(2, 'Stationery', 'School and office supplies', NOW(), NOW())");
+
+            statement.execute(
+                    "INSERT INTO items (item_id, name, description, category_id, unit_price, created_at, updated_at) VALUES "
+                            +
+                            "(1, 'Mathematics Textbook', 'Grade 10 Mathematics textbook', 1, 1500.00, NOW(), NOW()), " +
+                            "(2, 'Blue Pen', 'Blue ballpoint pen', 2, 25.00, NOW(), NOW()), " +
+                            "(3, 'Notebook', 'A4 ruled notebook', 2, 150.00, NOW(), NOW())");
+
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        itemDAO = new ItemDAO();
+    }
+
+    @Test
+    void shouldRetrieveExistingItems() {
+
+        List<Item> items = itemDAO.getAllItems();
+
+        assertNotNull(items, "Items list should not be null");
+        assertFalse(items.isEmpty(), "Should have items from seed data");
+
+        assertTrue(items.size() >= 3, "Should have at least 3 focused test items");
+
+        boolean hasMathBook = items.stream().anyMatch(i -> "Mathematics Textbook".equals(i.getName()));
+        boolean hasPen = items.stream().anyMatch(i -> "Blue Pen".equals(i.getName()));
+
+        assertTrue(hasMathBook, "Should have 'Mathematics Textbook' item from focused test data");
+        assertTrue(hasPen, "Should have 'Blue Pen' item from focused test data");
+
+        Item firstItem = items.get(0);
+        assertNotNull(firstItem.getCategory(), "Item should have category object populated");
+        assertNotNull(firstItem.getCategory().getName(), "Item category should have name");
+    }
+
+    @Test
+    void shouldRetrieveItemById() {
+
+        Item item = itemDAO.getItemById(1);
+
+        assertNotNull(item, "Should find item with ID 1");
+        assertEquals("Mathematics Textbook", item.getName(), "Item ID 1 should be 'Mathematics Textbook'");
+        assertEquals("Grade 10 Mathematics textbook", item.getDescription());
+        assertEquals(new BigDecimal("1500.00"), item.getUnitPrice());
+        assertNotNull(item.getCategory(), "Item should have category populated");
+        assertEquals("Books", item.getCategory().getName(), "Item should be in Books category");
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentItem() {
+
+        Item result = itemDAO.getItemById(99999);
+        assertNull(result, "Non-existent item should return null");
+    }
+
+    @Test
+    void shouldHandleInvalidIds() {
+
+        assertNull(itemDAO.getItemById(-1), "Negative ID should return null");
+        assertNull(itemDAO.getItemById(0), "Zero ID should return null");
+    }
+
+    @Test
+    void shouldCreateNewItem() {
+
+        Item newItem = new Item();
+        newItem.setName("Test Item " + System.currentTimeMillis());
+        newItem.setDescription("Test description");
+        newItem.setUnitPrice(new BigDecimal("999.99"));
+
+        Category category = new Category();
+        category.setCategoryId(1);
+        newItem.setCategory(category);
+
+        boolean created = itemDAO.createItem(newItem);
+        assertTrue(created, "Should successfully create new item");
+
+        List<Item> items = itemDAO.getAllItems();
+        boolean found = items.stream()
+                .anyMatch(i -> newItem.getName().equals(i.getName()));
+        assertTrue(found, "New item should appear in items list");
+    }
+
+    @Test
+    void shouldUpdateExistingItem() {
+
+        Item testItem = new Item();
+        testItem.setName("Update Test Item " + System.currentTimeMillis());
+        testItem.setDescription("Original description");
+        testItem.setUnitPrice(new BigDecimal("500.00"));
+
+        Category category = new Category();
+        category.setCategoryId(1);
+        testItem.setCategory(category);
+
+        assertTrue(itemDAO.createItem(testItem), "Should create test item");
+
+        List<Item> items = itemDAO.getAllItems();
+        Item createdItem = items.stream()
+                .filter(i -> testItem.getName().equals(i.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdItem, "Should find the created item");
+
+        String newDescription = "Updated description " + System.currentTimeMillis();
+        BigDecimal newPrice = new BigDecimal("750.00");
+        createdItem.setDescription(newDescription);
+        createdItem.setUnitPrice(newPrice);
+
+        boolean updated = itemDAO.updateItem(createdItem);
+        assertTrue(updated, "Should successfully update item");
+
+        Item updatedItem = itemDAO.getItemById(createdItem.getItemId());
+        assertNotNull(updatedItem, "Should still find the updated item");
+        assertEquals(newDescription, updatedItem.getDescription(), "Description should be updated");
+        assertEquals(newPrice, updatedItem.getUnitPrice(), "Price should be updated");
+    }
+
+    @Test
+    void shouldDeleteItem() {
+
+        Item itemToDelete = new Item();
+        itemToDelete.setName("Temp Delete Item " + System.currentTimeMillis());
+        itemToDelete.setDescription("Temporary item for deletion test");
+        itemToDelete.setUnitPrice(new BigDecimal("100.00"));
+
+        Category category = new Category();
+        category.setCategoryId(1);
+        itemToDelete.setCategory(category);
+
+        boolean created = itemDAO.createItem(itemToDelete);
+        assertTrue(created, "Should create temporary item");
+
+        List<Item> items = itemDAO.getAllItems();
+        Item createdItem = items.stream()
+                .filter(i -> itemToDelete.getName().equals(i.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(createdItem, "Should find the created item");
+
+        boolean deleted = itemDAO.deleteItem(createdItem.getItemId());
+        assertTrue(deleted, "Should successfully delete item");
+
+        Item deletedItem = itemDAO.getItemById(createdItem.getItemId());
+        assertNull(deletedItem, "Deleted item should not be retrievable");
+    }
+
+    @Test
+    void shouldCheckItemNameExists() {
+
+        assertTrue(itemDAO.isItemNameExists("Mathematics Textbook"),
+                "Should find existing 'Mathematics Textbook' item");
+        assertFalse(itemDAO.isItemNameExists("NonExistentItem"), "Should not find non-existent item");
+    }
+
+    @Test
+    void shouldGetItemsByCategory() {
+
+        List<Item> booksItems = itemDAO.getItemsByCategory(1);
+
+        assertNotNull(booksItems, "Books items list should not be null");
+        assertFalse(booksItems.isEmpty(), "Books category should have items from seed data");
+
+        for (Item item : booksItems) {
+            assertNotNull(item.getCategory(), "Item should have category populated");
+            assertEquals("Books", item.getCategory().getName(), "All items should be in Books category");
+        }
+    }
+
+    @Test
+    void shouldHandleNullAndInvalidInputs() {
+
+        assertFalse(itemDAO.createItem(null), "Creating null item should return false");
+        assertFalse(itemDAO.updateItem(null), "Updating null item should return false");
+        assertFalse(itemDAO.deleteItem(-1), "Deleting with negative ID should return false");
+        assertFalse(itemDAO.isItemNameExists(null), "Checking null name should return false");
+        assertFalse(itemDAO.isItemNameExists(""), "Checking empty name should return false");
+
+        List<Item> invalidCategoryItems = itemDAO.getItemsByCategory(99999);
+        assertNotNull(invalidCategoryItems, "Should return empty list for invalid category");
+        assertTrue(invalidCategoryItems.isEmpty(), "Should return empty list for invalid category");
+    }
+
+    @Test
+    void shouldHandleItemsWithoutCategory() {
+
+        List<Item> allItems = itemDAO.getAllItems();
+
+        for (Item item : allItems) {
+            assertNotNull(item.getCategory(), "All items should have categories");
+            assertNotNull(item.getCategory().getName(), "All categories should have names");
+        }
+    }
+
+    @Test
+    void shouldValidateItemCreationRequirements() {
+
+        Item invalidItem = new Item();
+
+        invalidItem.setDescription("Description");
+        invalidItem.setUnitPrice(new BigDecimal("100.00"));
+        Category category = new Category();
+        category.setCategoryId(1);
+        invalidItem.setCategory(category);
+
+        assertFalse(itemDAO.createItem(invalidItem), "Item without name should fail to create");
+
+        Item itemWithoutCategory = new Item();
+        itemWithoutCategory.setName("Test Item " + System.currentTimeMillis());
+        itemWithoutCategory.setDescription("Description");
+        itemWithoutCategory.setUnitPrice(new BigDecimal("100.00"));
+
+        assertFalse(itemDAO.createItem(itemWithoutCategory), "Item without category should fail to create");
+    }
+}

--- a/src/test/java/com/pahanaedu/dao/UserDAOTest.java
+++ b/src/test/java/com/pahanaedu/dao/UserDAOTest.java
@@ -1,0 +1,253 @@
+package com.pahanaedu.dao;
+
+import com.pahanaedu.helpers.DatabaseHelper;
+import com.pahanaedu.model.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserDAOTest {
+
+    private UserDAO userDAO;
+
+    @BeforeAll
+    static void setupDatabase() throws SQLException {
+
+        try (Connection connection = DatabaseHelper.getInstance().getConnection();
+                Statement statement = connection.createStatement()) {
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+            statement.execute("DELETE FROM users");
+            statement.execute("ALTER TABLE users AUTO_INCREMENT = 1");
+
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+            statement.execute(
+                    "INSERT INTO users (user_id, email, password, first_name, last_name, role, created_at, updated_at) VALUES "
+                            +
+                            "(1, 'admin@pahanaedu.com', 'admin123', 'Admin', 'User', 'ADMIN', NOW(), NOW()), " +
+                            "(2, 'cashier@pahanaedu.com', 'cashier123', 'Cashier', 'User', 'CASHIER', NOW(), NOW())");
+
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        userDAO = new UserDAO();
+    }
+
+    @Test
+    void shouldRetrieveExistingUsers() {
+
+        List<User> users = userDAO.getAllUsers();
+
+        assertNotNull(users, "Users list should not be null");
+        assertFalse(users.isEmpty(), "Should have users from seed data");
+
+        assertTrue(users.size() >= 2, "Should have at least 2 seed users");
+
+        boolean hasAdmin = users.stream().anyMatch(u -> "admin@pahanaedu.com".equals(u.getEmail()));
+        boolean hasCashier = users.stream().anyMatch(u -> "cashier@pahanaedu.com".equals(u.getEmail()));
+
+        assertTrue(hasAdmin, "Should have admin user from seed data");
+        assertTrue(hasCashier, "Should have cashier user from seed data");
+    }
+
+    @Test
+    void shouldRetrieveUserById() {
+
+        User user = userDAO.getUserById(1);
+
+        assertNotNull(user, "Should find user with ID 1");
+        assertEquals("admin@pahanaedu.com", user.getEmail(), "User ID 1 should be admin");
+        assertEquals("Admin", user.getFirstName(), "First name should match seed data");
+        assertEquals("User", user.getLastName(), "Last name should match seed data");
+        assertEquals("ADMIN", user.getRole(), "Role should match seed data");
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentUser() {
+
+        User result = userDAO.getUserById(99999);
+        assertNull(result, "Non-existent user should return null");
+    }
+
+    @Test
+    void shouldHandleInvalidIds() {
+
+        assertNull(userDAO.getUserById(-1), "Negative ID should return null");
+        assertNull(userDAO.getUserById(0), "Zero ID should return null");
+    }
+
+    @Test
+    void shouldRetrieveUserByEmail() {
+
+        User user = userDAO.getUserByEmail("admin@pahanaedu.com");
+
+        assertNotNull(user, "Should find admin user by email");
+        assertEquals("admin@pahanaedu.com", user.getEmail(), "Email should match");
+        assertEquals("Admin", user.getFirstName(), "First name should match");
+        assertEquals("ADMIN", user.getRole(), "Role should match");
+    }
+
+    @Test
+    void shouldReturnNullForNonExistentEmail() {
+
+        User result = userDAO.getUserByEmail("nonexistent@example.com");
+        assertNull(result, "Non-existent email should return null");
+    }
+
+    @Test
+    void shouldCreateNewUser() {
+
+        User newUser = new User();
+        newUser.setEmail("test" + System.currentTimeMillis() + "@pahanaedu.com");
+        newUser.setPassword("testpass123");
+        newUser.setFirstName("Test");
+        newUser.setLastName("User");
+        newUser.setRole("CASHIER");
+
+        User createdUser = userDAO.createUser(newUser);
+        assertNotNull(createdUser, "Should successfully create new user");
+        assertTrue(createdUser.getUserId() > 0, "Created user should have positive ID");
+
+        User retrievedUser = userDAO.getUserById(createdUser.getUserId());
+        assertNotNull(retrievedUser, "Should be able to retrieve created user");
+        assertEquals(newUser.getEmail(), retrievedUser.getEmail(), "Email should match");
+        assertEquals(newUser.getFirstName(), retrievedUser.getFirstName(), "First name should match");
+    }
+
+    @Test
+    void shouldUpdateExistingUser() {
+
+        User testUser = new User();
+        testUser.setEmail("update" + System.currentTimeMillis() + "@pahanaedu.com");
+        testUser.setPassword("originalpass");
+        testUser.setFirstName("Original");
+        testUser.setLastName("Name");
+        testUser.setRole("CASHIER");
+
+        User createdUser = userDAO.createUser(testUser);
+        assertNotNull(createdUser, "Should create test user");
+
+        createdUser.setFirstName("Updated");
+        createdUser.setLastName("User");
+        createdUser.setRole("ADMIN");
+
+        boolean updated = userDAO.updateUser(createdUser, "newpassword");
+        assertTrue(updated, "Should successfully update user");
+
+        User updatedUser = userDAO.getUserById(createdUser.getUserId());
+        assertNotNull(updatedUser, "Should find the updated user");
+        assertEquals("Updated", updatedUser.getFirstName(), "First name should be updated");
+        assertEquals("User", updatedUser.getLastName(), "Last name should be updated");
+        assertEquals("ADMIN", updatedUser.getRole(), "Role should be updated");
+    }
+
+    @Test
+    void shouldUpdateUserWithoutPassword() {
+
+        User testUser = new User();
+        testUser.setEmail("nopassupdate" + System.currentTimeMillis() + "@pahanaedu.com");
+        testUser.setPassword("keepthispass");
+        testUser.setFirstName("Keep");
+        testUser.setLastName("Password");
+        testUser.setRole("CASHIER");
+
+        User createdUser = userDAO.createUser(testUser);
+        assertNotNull(createdUser, "Should create test user");
+
+        createdUser.setFirstName("Changed");
+        boolean updated = userDAO.updateUser(createdUser, null);
+        assertTrue(updated, "Should successfully update user without password change");
+
+        User updatedUser = userDAO.getUserById(createdUser.getUserId());
+        assertEquals("Changed", updatedUser.getFirstName(), "First name should be updated");
+    }
+
+    @Test
+    void shouldDeleteUser() {
+
+        User userToDelete = new User();
+        userToDelete.setEmail("delete" + System.currentTimeMillis() + "@pahanaedu.com");
+        userToDelete.setPassword("deletepass");
+        userToDelete.setFirstName("Delete");
+        userToDelete.setLastName("Me");
+        userToDelete.setRole("CASHIER");
+
+        User createdUser = userDAO.createUser(userToDelete);
+        assertNotNull(createdUser, "Should create temporary user");
+
+        boolean deleted = userDAO.deleteUser(createdUser.getUserId());
+        assertTrue(deleted, "Should successfully delete user");
+
+        User deletedUser = userDAO.getUserById(createdUser.getUserId());
+        assertNull(deletedUser, "Deleted user should not be retrievable");
+    }
+
+    @Test
+    void shouldCheckEmailExists() {
+
+        assertTrue(userDAO.emailExists("admin@pahanaedu.com"), "Should find existing admin email");
+        assertFalse(userDAO.emailExists("nonexistent@example.com"), "Should not find non-existent email");
+    }
+
+    @Test
+    void shouldCheckEmailExistsWithExclusion() {
+
+        assertFalse(userDAO.emailExists("admin@pahanaedu.com", 1), "Should exclude user ID 1 (admin)");
+        assertTrue(userDAO.emailExists("admin@pahanaedu.com", 2),
+                "Should find admin email when excluding different user");
+    }
+
+    @Test
+    void shouldUpdateLastLogin() {
+
+        boolean updated = userDAO.updateLastLogin(1);
+        assertTrue(updated, "Should successfully update last login for existing user");
+
+        assertFalse(userDAO.updateLastLogin(99999), "Should return false for non-existent user");
+    }
+
+    @Test
+    void shouldHandleNullAndInvalidInputs() {
+
+        assertNull(userDAO.createUser(null), "Creating null user should return null");
+        assertFalse(userDAO.updateUser(null, "password"), "Updating null user should return false");
+        assertFalse(userDAO.deleteUser(-1), "Deleting with negative ID should return false");
+        assertFalse(userDAO.emailExists(null), "Checking null email should return false");
+        assertFalse(userDAO.emailExists(""), "Checking empty email should return false");
+        assertNull(userDAO.getUserByEmail(null), "Getting user with null email should return null");
+        assertNull(userDAO.getUserByEmail(""), "Getting user with empty email should return null");
+    }
+
+    @Test
+    void shouldValidateUserCreationRequirements() {
+
+        User invalidUser = new User();
+
+        invalidUser.setPassword("password");
+        invalidUser.setFirstName("Test");
+        invalidUser.setLastName("User");
+        invalidUser.setRole("CASHIER");
+
+        assertNull(userDAO.createUser(invalidUser), "User without email should fail to create");
+
+        User duplicateEmailUser = new User();
+        duplicateEmailUser.setEmail("admin@pahanaedu.com");
+        duplicateEmailUser.setPassword("password");
+        duplicateEmailUser.setFirstName("Duplicate");
+        duplicateEmailUser.setLastName("User");
+        duplicateEmailUser.setRole("CASHIER");
+
+        assertNull(userDAO.createUser(duplicateEmailUser), "User with duplicate email should fail to create");
+    }
+}

--- a/src/test/java/com/pahanaedu/enums/PaymentMethodTest.java
+++ b/src/test/java/com/pahanaedu/enums/PaymentMethodTest.java
@@ -1,0 +1,41 @@
+package com.pahanaedu.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentMethodTest {
+
+    @Test
+    void shouldHaveCorrectEnumValues() {
+        PaymentMethod[] values = PaymentMethod.values();
+        assertEquals(4, values.length);
+    }
+
+    @Test
+    void shouldGenerateDisplayNames() {
+        assertEquals("Cash", PaymentMethod.CASH.getDisplayName());
+        assertEquals("Credit Card", PaymentMethod.CREDIT_CARD.getDisplayName());
+        assertEquals("Debit Card", PaymentMethod.DEBIT_CARD.getDisplayName());
+        assertEquals("Bank Transfer", PaymentMethod.BANK_TRANSFER.getDisplayName());
+    }
+
+    @Test
+    void shouldGenerateCssClasses() {
+        assertEquals("payment-cash", PaymentMethod.CASH.getCssClass());
+        assertEquals("payment-credit-card", PaymentMethod.CREDIT_CARD.getCssClass());
+        assertEquals("payment-debit-card", PaymentMethod.DEBIT_CARD.getCssClass());
+        assertEquals("payment-bank-transfer", PaymentMethod.BANK_TRANSFER.getCssClass());
+    }
+
+    @Test
+    void shouldParseFromString() {
+        assertEquals(PaymentMethod.CASH, PaymentMethod.fromString("CASH"));
+        assertEquals(PaymentMethod.CREDIT_CARD, PaymentMethod.fromString("CREDIT_CARD"));
+        assertNull(PaymentMethod.fromString(null));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidString() {
+        assertThrows(IllegalArgumentException.class, () -> PaymentMethod.fromString("INVALID"));
+    }
+}

--- a/src/test/java/com/pahanaedu/enums/PaymentStatusTest.java
+++ b/src/test/java/com/pahanaedu/enums/PaymentStatusTest.java
@@ -1,0 +1,42 @@
+package com.pahanaedu.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentStatusTest {
+
+    @Test
+    void shouldHaveCorrectEnumValues() {
+        PaymentStatus[] values = PaymentStatus.values();
+        assertEquals(3, values.length);
+        assertEquals(PaymentStatus.PENDING, values[0]);
+        assertEquals(PaymentStatus.PAID, values[1]);
+        assertEquals(PaymentStatus.CANCELLED, values[2]);
+    }
+
+    @Test
+    void shouldGenerateDisplayNames() {
+        assertEquals("Pending", PaymentStatus.PENDING.getDisplayName());
+        assertEquals("Paid", PaymentStatus.PAID.getDisplayName());
+        assertEquals("Cancelled", PaymentStatus.CANCELLED.getDisplayName());
+    }
+
+    @Test
+    void shouldGenerateCssClasses() {
+        assertEquals("status-pending", PaymentStatus.PENDING.getCssClass());
+        assertEquals("status-paid", PaymentStatus.PAID.getCssClass());
+        assertEquals("status-cancelled", PaymentStatus.CANCELLED.getCssClass());
+    }
+
+    @Test
+    void shouldParseFromString() {
+        assertEquals(PaymentStatus.PENDING, PaymentStatus.fromString("PENDING"));
+        assertEquals(PaymentStatus.PAID, PaymentStatus.fromString("PAID"));
+        assertNull(PaymentStatus.fromString(null));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidString() {
+        assertThrows(IllegalArgumentException.class, () -> PaymentStatus.fromString("INVALID"));
+    }
+}

--- a/src/test/java/com/pahanaedu/enums/UserRoleTest.java
+++ b/src/test/java/com/pahanaedu/enums/UserRoleTest.java
@@ -1,0 +1,36 @@
+package com.pahanaedu.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserRoleTest {
+    @Test
+    void shouldHaveCorrectEnumValues() {
+        UserRole[] values = UserRole.values();
+        assertEquals(2, values.length);
+    }
+
+    @Test
+    void shouldGenerateDisplayNames() {
+        assertEquals("Administrator", UserRole.ADMIN.getDisplayName());
+        assertEquals("Cashier", UserRole.CASHIER.getDisplayName());
+    }
+
+    @Test
+    void shouldGenerateCssClasses() {
+        assertEquals("role-admin", UserRole.ADMIN.getCssClass());
+        assertEquals("role-cashier", UserRole.CASHIER.getCssClass());
+    }
+
+    @Test
+    void shouldParseFromString() {
+        assertEquals(UserRole.ADMIN, UserRole.fromString("ADMIN"));
+        assertEquals(UserRole.CASHIER, UserRole.fromString("CASHIER"));
+        assertNull(UserRole.fromString(null));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidString() {
+        assertThrows(IllegalArgumentException.class, () -> UserRole.fromString("INVALID"));
+    }
+}

--- a/src/test/java/com/pahanaedu/model/BillItemTest.java
+++ b/src/test/java/com/pahanaedu/model/BillItemTest.java
@@ -1,0 +1,207 @@
+package com.pahanaedu.model;
+
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BillItemTest {
+    @Test
+    void shouldCreateDefaultBillItem() {
+        BillItem billItem = new BillItem();
+        assertNotNull(billItem);
+        assertEquals(0, billItem.getBillItemId());
+        assertEquals(0, billItem.getBillId());
+        assertEquals(0, billItem.getItemId());
+        assertEquals(0, billItem.getQuantity());
+        assertEquals(BigDecimal.ZERO, billItem.getUnitPrice());
+        assertEquals(BigDecimal.ZERO, billItem.getLineTotal());
+        assertNull(billItem.getItem());
+    }
+
+    @Test
+    void shouldCreateBillItemWithBasicParameters() {
+        BillItem billItem = new BillItem(1, 2, 5, new BigDecimal("10.00"));
+        assertEquals(1, billItem.getBillId());
+        assertEquals(2, billItem.getItemId());
+        assertEquals(5, billItem.getQuantity());
+        assertEquals(new BigDecimal("10.00"), billItem.getUnitPrice());
+        assertEquals(new BigDecimal("50.00"), billItem.getLineTotal());
+    }
+
+    @Test
+    void shouldCreateBillItemWithItem() {
+        Item item = new Item("Test Item", "Test Description", 1, new BigDecimal("15.00"));
+        item.setItemId(123);
+        BillItem billItem = new BillItem(1, item, 3);
+        assertEquals(1, billItem.getBillId());
+        assertEquals(123, billItem.getItemId());
+        assertEquals(3, billItem.getQuantity());
+        assertEquals(new BigDecimal("15.00"), billItem.getUnitPrice());
+        assertEquals(new BigDecimal("45.00"), billItem.getLineTotal());
+        assertEquals(item, billItem.getItem());
+    }
+
+    @Test
+    void shouldSetAndGetBillItemId() {
+        BillItem billItem = new BillItem();
+        billItem.setBillItemId(456);
+        assertEquals(456, billItem.getBillItemId());
+    }
+
+    @Test
+    void shouldSetAndGetBillId() {
+        BillItem billItem = new BillItem();
+        billItem.setBillId(789);
+        assertEquals(789, billItem.getBillId());
+    }
+
+    @Test
+    void shouldSetAndGetItemId() {
+        BillItem billItem = new BillItem();
+        billItem.setItemId(101);
+        assertEquals(101, billItem.getItemId());
+    }
+
+    @Test
+    void shouldSetAndGetQuantity() {
+        BillItem billItem = new BillItem();
+        billItem.setQuantity(7);
+        assertEquals(7, billItem.getQuantity());
+    }
+
+    @Test
+    void shouldSetAndGetUnitPrice() {
+        BillItem billItem = new BillItem();
+        billItem.setUnitPrice(new BigDecimal("25.50"));
+        assertEquals(new BigDecimal("25.50"), billItem.getUnitPrice());
+    }
+
+    @Test
+    void shouldSetAndGetLineTotal() {
+        BillItem billItem = new BillItem();
+        billItem.setLineTotal(new BigDecimal("100.00"));
+        assertEquals(new BigDecimal("100.00"), billItem.getLineTotal());
+    }
+
+    @Test
+    void shouldSetAndGetItem() {
+        BillItem billItem = new BillItem();
+        Item item = new Item("Product", "Description", 1, new BigDecimal("20.00"));
+        item.setItemId(555);
+        billItem.setItem(item);
+        assertEquals(item, billItem.getItem());
+        assertEquals(555, billItem.getItemId());
+        assertEquals(new BigDecimal("20.00"), billItem.getUnitPrice());
+    }
+
+    @Test
+    void shouldSetAndGetCreatedAt() {
+        BillItem billItem = new BillItem();
+        LocalDateTime now = LocalDateTime.now();
+        billItem.setCreatedAt(now);
+        assertEquals(now, billItem.getCreatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetUpdatedAt() {
+        BillItem billItem = new BillItem();
+        LocalDateTime now = LocalDateTime.now();
+        billItem.setUpdatedAt(now);
+        assertEquals(now, billItem.getUpdatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetDeletedAt() {
+        BillItem billItem = new BillItem();
+        LocalDateTime now = LocalDateTime.now();
+        billItem.setDeletedAt(now);
+        assertEquals(now, billItem.getDeletedAt());
+    }
+
+    @Test
+    void shouldCalculateLineTotal() {
+        BillItem billItem = new BillItem();
+        billItem.setQuantity(4);
+        billItem.setUnitPrice(new BigDecimal("12.50"));
+        assertEquals(new BigDecimal("50.00"), billItem.calculateLineTotal());
+    }
+
+    @Test
+    void shouldReturnZeroLineTotalForZeroQuantity() {
+        BillItem billItem = new BillItem();
+        billItem.setQuantity(0);
+        billItem.setUnitPrice(new BigDecimal("10.00"));
+        assertEquals(BigDecimal.ZERO, billItem.calculateLineTotal());
+    }
+
+    @Test
+    void shouldUpdateLineTotal() {
+        BillItem billItem = new BillItem();
+        billItem.setQuantity(6);
+        billItem.setUnitPrice(new BigDecimal("8.00"));
+        billItem.updateLineTotal();
+        assertEquals(new BigDecimal("48.00"), billItem.getLineTotal());
+    }
+
+    @Test
+    void shouldReturnItemName() {
+        Item item = new Item("Laptop", "Gaming laptop", 1, new BigDecimal("1500.00"));
+        BillItem billItem = new BillItem();
+        billItem.setItem(item);
+        assertEquals("Laptop", billItem.getItemName());
+    }
+
+    @Test
+    void shouldReturnNullItemNameWhenNoItem() {
+        BillItem billItem = new BillItem();
+        assertNull(billItem.getItemName());
+    }
+
+    @Test
+    void shouldReturnItemDescription() {
+        Item item = new Item("Mouse", "Wireless optical mouse", 1, new BigDecimal("25.00"));
+        BillItem billItem = new BillItem();
+        billItem.setItem(item);
+        assertEquals("Wireless optical mouse", billItem.getItemDescription());
+    }
+
+    @Test
+    void shouldReturnNullItemDescriptionWhenNoItem() {
+        BillItem billItem = new BillItem();
+        assertNull(billItem.getItemDescription());
+    }
+
+    @Test
+    void shouldReturnCategoryName() {
+        Category category = new Category("Electronics", "Electronic devices");
+        Item item = new Item("Tablet", "10-inch tablet", category, new BigDecimal("300.00"));
+        BillItem billItem = new BillItem();
+        billItem.setItem(item);
+        assertEquals("Electronics", billItem.getCategoryName());
+    }
+
+    @Test
+    void shouldReturnNullCategoryNameWhenNoItem() {
+        BillItem billItem = new BillItem();
+        assertNull(billItem.getCategoryName());
+    }
+
+    @Test
+    void shouldRecalculateLineTotalWhenQuantityChanges() {
+        BillItem billItem = new BillItem(1, 2, 3, new BigDecimal("10.00"));
+        assertEquals(new BigDecimal("30.00"), billItem.getLineTotal());
+
+        billItem.setQuantity(5);
+        assertEquals(new BigDecimal("50.00"), billItem.getLineTotal());
+    }
+
+    @Test
+    void shouldRecalculateLineTotalWhenUnitPriceChanges() {
+        BillItem billItem = new BillItem(1, 2, 4, new BigDecimal("5.00"));
+        assertEquals(new BigDecimal("20.00"), billItem.getLineTotal());
+
+        billItem.setUnitPrice(new BigDecimal("7.50"));
+        assertEquals(new BigDecimal("30.00"), billItem.getLineTotal());
+    }
+}

--- a/src/test/java/com/pahanaedu/model/BillTest.java
+++ b/src/test/java/com/pahanaedu/model/BillTest.java
@@ -1,0 +1,202 @@
+package com.pahanaedu.model;
+
+import com.pahanaedu.enums.PaymentMethod;
+import com.pahanaedu.enums.PaymentStatus;
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BillTest {
+    @Test
+    void shouldCreateDefaultBill() {
+        Bill bill = new Bill();
+        assertNotNull(bill);
+        assertEquals(0, bill.getBillId());
+        assertEquals(0, bill.getCustomerId());
+        assertEquals(0, bill.getUserId());
+        assertEquals(BigDecimal.ZERO, bill.getTotalAmount());
+        assertEquals(PaymentStatus.PENDING, bill.getPaymentStatus());
+        assertEquals(PaymentMethod.CASH, bill.getPaymentMethod());
+        assertNull(bill.getNotes());
+        assertNull(bill.getBillItems());
+    }
+
+    @Test
+    void shouldCreateBillWithParameters() {
+        Bill bill = new Bill(1, 2, new BigDecimal("500.00"), PaymentStatus.PAID, PaymentMethod.CASH, "Test bill");
+        assertEquals(1, bill.getCustomerId());
+        assertEquals(2, bill.getUserId());
+        assertEquals(new BigDecimal("500.00"), bill.getTotalAmount());
+        assertEquals(PaymentStatus.PAID, bill.getPaymentStatus());
+        assertEquals(PaymentMethod.CASH, bill.getPaymentMethod());
+        assertEquals("Test bill", bill.getNotes());
+    }
+
+    @Test
+    void shouldSetAndGetBillId() {
+        Bill bill = new Bill();
+        bill.setBillId(456);
+        assertEquals(456, bill.getBillId());
+    }
+
+    @Test
+    void shouldSetAndGetCustomerId() {
+        Bill bill = new Bill();
+        bill.setCustomerId(789);
+        assertEquals(789, bill.getCustomerId());
+    }
+
+    @Test
+    void shouldSetAndGetUserId() {
+        Bill bill = new Bill();
+        bill.setUserId(123);
+        assertEquals(123, bill.getUserId());
+    }
+
+    @Test
+    void shouldSetAndGetTotalAmount() {
+        Bill bill = new Bill();
+        bill.setTotalAmount(new BigDecimal("500.00"));
+        assertEquals(new BigDecimal("500.00"), bill.getTotalAmount());
+    }
+
+    @Test
+    void shouldSetAndGetPaymentStatus() {
+        Bill bill = new Bill();
+        bill.setPaymentStatus(PaymentStatus.PENDING);
+        assertEquals(PaymentStatus.PENDING, bill.getPaymentStatus());
+    }
+
+    @Test
+    void shouldSetAndGetPaymentMethod() {
+        Bill bill = new Bill();
+        bill.setPaymentMethod(PaymentMethod.CREDIT_CARD);
+        assertEquals(PaymentMethod.CREDIT_CARD, bill.getPaymentMethod());
+    }
+
+    @Test
+    void shouldSetAndGetNotes() {
+        Bill bill = new Bill();
+        bill.setNotes("Important notes");
+        assertEquals("Important notes", bill.getNotes());
+    }
+
+    @Test
+    void shouldSetAndGetBillItems() {
+        Bill bill = new Bill();
+        List<BillItem> items = new ArrayList<>();
+        items.add(new BillItem());
+        bill.setBillItems(items);
+        assertEquals(items, bill.getBillItems());
+        assertEquals(1, bill.getBillItems().size());
+    }
+
+    @Test
+    void shouldSetAndGetCustomer() {
+        Bill bill = new Bill();
+        Customer customer = new Customer("000123", "John Doe", "123 Main St", "555-0123", "john@example.com");
+        bill.setCustomer(customer);
+        assertEquals(customer, bill.getCustomer());
+    }
+
+    @Test
+    void shouldSetAndGetUser() {
+        Bill bill = new Bill();
+        User user = new User();
+        bill.setUser(user);
+        assertEquals(user, bill.getUser());
+    }
+
+    @Test
+    void shouldSetAndGetCreatedAt() {
+        Bill bill = new Bill();
+        LocalDateTime now = LocalDateTime.now();
+        bill.setCreatedAt(now);
+        assertEquals(now, bill.getCreatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetUpdatedAt() {
+        Bill bill = new Bill();
+        LocalDateTime now = LocalDateTime.now();
+        bill.setUpdatedAt(now);
+        assertEquals(now, bill.getUpdatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetDeletedAt() {
+        Bill bill = new Bill();
+        LocalDateTime now = LocalDateTime.now();
+        bill.setDeletedAt(now);
+        assertEquals(now, bill.getDeletedAt());
+    }
+
+    @Test
+    void shouldCalculateTotalFromBillItems() {
+        Bill bill = new Bill();
+        List<BillItem> items = new ArrayList<>();
+
+        BillItem item1 = new BillItem();
+        item1.setLineTotal(new BigDecimal("100.00"));
+
+        BillItem item2 = new BillItem();
+        item2.setLineTotal(new BigDecimal("150.00"));
+
+        items.add(item1);
+        items.add(item2);
+        bill.setBillItems(items);
+
+        assertEquals(new BigDecimal("250.00"), bill.calculateTotal());
+    }
+
+    @Test
+    void shouldReturnZeroTotalForEmptyBillItems() {
+        Bill bill = new Bill();
+        assertEquals(BigDecimal.ZERO, bill.calculateTotal());
+    }
+
+    @Test
+    void shouldCalculateAndReturnTotal() {
+        Bill bill = new Bill();
+        List<BillItem> items = new ArrayList<>();
+
+        BillItem item = new BillItem();
+        item.setLineTotal(new BigDecimal("75.00"));
+        items.add(item);
+
+        bill.setBillItems(items);
+
+        assertEquals(new BigDecimal("75.00"), bill.calculateTotal());
+    }
+
+    @Test
+    void shouldReturnItemCount() {
+        Bill bill = new Bill();
+        List<BillItem> items = new ArrayList<>();
+        items.add(new BillItem());
+        items.add(new BillItem());
+        bill.setBillItems(items);
+        assertEquals(2, bill.getItemCount());
+    }
+
+    @Test
+    void shouldReturnTotalQuantity() {
+        Bill bill = new Bill();
+        List<BillItem> items = new ArrayList<>();
+
+        BillItem item1 = new BillItem();
+        item1.setQuantity(3);
+
+        BillItem item2 = new BillItem();
+        item2.setQuantity(5);
+
+        items.add(item1);
+        items.add(item2);
+        bill.setBillItems(items);
+
+        assertEquals(8, bill.getTotalQuantity());
+    }
+}

--- a/src/test/java/com/pahanaedu/model/CategoryTest.java
+++ b/src/test/java/com/pahanaedu/model/CategoryTest.java
@@ -1,0 +1,68 @@
+package com.pahanaedu.model;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CategoryTest {
+    @Test
+    void shouldCreateDefaultCategory() {
+        Category category = new Category();
+        assertNotNull(category);
+        assertEquals(0, category.getCategoryId());
+        assertNull(category.getName());
+        assertNull(category.getDescription());
+    }
+
+    @Test
+    void shouldCreateCategoryWithParameters() {
+        Category category = new Category("Electronics", "Electronic devices and accessories");
+        assertEquals("Electronics", category.getName());
+        assertEquals("Electronic devices and accessories", category.getDescription());
+    }
+
+    @Test
+    void shouldSetAndGetCategoryId() {
+        Category category = new Category();
+        category.setCategoryId(789);
+        assertEquals(789, category.getCategoryId());
+    }
+
+    @Test
+    void shouldSetAndGetName() {
+        Category category = new Category();
+        category.setName("Books");
+        assertEquals("Books", category.getName());
+    }
+
+    @Test
+    void shouldSetAndGetDescription() {
+        Category category = new Category();
+        category.setDescription("Educational books and materials");
+        assertEquals("Educational books and materials", category.getDescription());
+    }
+
+    @Test
+    void shouldSetAndGetCreatedAt() {
+        Category category = new Category();
+        LocalDateTime now = LocalDateTime.now();
+        category.setCreatedAt(now);
+        assertEquals(now, category.getCreatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetUpdatedAt() {
+        Category category = new Category();
+        LocalDateTime now = LocalDateTime.now();
+        category.setUpdatedAt(now);
+        assertEquals(now, category.getUpdatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetDeletedAt() {
+        Category category = new Category();
+        LocalDateTime now = LocalDateTime.now();
+        category.setDeletedAt(now);
+        assertEquals(now, category.getDeletedAt());
+    }
+}

--- a/src/test/java/com/pahanaedu/model/CustomerTest.java
+++ b/src/test/java/com/pahanaedu/model/CustomerTest.java
@@ -1,0 +1,95 @@
+package com.pahanaedu.model;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomerTest {
+    @Test
+    void shouldCreateDefaultCustomer() {
+        Customer customer = new Customer();
+        assertNotNull(customer);
+        assertEquals(0, customer.getCustomerId());
+        assertNull(customer.getAccountNumber());
+        assertNull(customer.getName());
+        assertNull(customer.getAddress());
+        assertNull(customer.getTelephone());
+        assertNull(customer.getEmail());
+    }
+
+    @Test
+    void shouldCreateCustomerWithParameters() {
+        Customer customer = new Customer("000123", "John Doe", "123 Main St", "555-0123", "john@example.com");
+        assertEquals("000123", customer.getAccountNumber());
+        assertEquals("John Doe", customer.getName());
+        assertEquals("123 Main St", customer.getAddress());
+        assertEquals("555-0123", customer.getTelephone());
+        assertEquals("john@example.com", customer.getEmail());
+    }
+
+    @Test
+    void shouldSetAndGetCustomerId() {
+        Customer customer = new Customer();
+        customer.setCustomerId(456);
+        assertEquals(456, customer.getCustomerId());
+    }
+
+    @Test
+    void shouldSetAndGetAccountNumber() {
+        Customer customer = new Customer();
+        customer.setAccountNumber("000789");
+        assertEquals("000789", customer.getAccountNumber());
+    }
+
+    @Test
+    void shouldSetAndGetName() {
+        Customer customer = new Customer();
+        customer.setName("Alice Smith");
+        assertEquals("Alice Smith", customer.getName());
+    }
+
+    @Test
+    void shouldSetAndGetAddress() {
+        Customer customer = new Customer();
+        customer.setAddress("456 Oak Ave");
+        assertEquals("456 Oak Ave", customer.getAddress());
+    }
+
+    @Test
+    void shouldSetAndGetTelephone() {
+        Customer customer = new Customer();
+        customer.setTelephone("555-9876");
+        assertEquals("555-9876", customer.getTelephone());
+    }
+
+    @Test
+    void shouldSetAndGetEmail() {
+        Customer customer = new Customer();
+        customer.setEmail("alice@example.com");
+        assertEquals("alice@example.com", customer.getEmail());
+    }
+
+    @Test
+    void shouldSetAndGetCreatedAt() {
+        Customer customer = new Customer();
+        LocalDateTime now = LocalDateTime.now();
+        customer.setCreatedAt(now);
+        assertEquals(now, customer.getCreatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetUpdatedAt() {
+        Customer customer = new Customer();
+        LocalDateTime now = LocalDateTime.now();
+        customer.setUpdatedAt(now);
+        assertEquals(now, customer.getUpdatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetDeletedAt() {
+        Customer customer = new Customer();
+        LocalDateTime now = LocalDateTime.now();
+        customer.setDeletedAt(now);
+        assertEquals(now, customer.getDeletedAt());
+    }
+}

--- a/src/test/java/com/pahanaedu/model/ItemTest.java
+++ b/src/test/java/com/pahanaedu/model/ItemTest.java
@@ -1,0 +1,120 @@
+package com.pahanaedu.model;
+
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ItemTest {
+    @Test
+    void shouldCreateDefaultItem() {
+        Item item = new Item();
+        assertNotNull(item);
+        assertEquals(0, item.getItemId());
+        assertNull(item.getName());
+        assertNull(item.getDescription());
+        assertNull(item.getCategoryId());
+        assertNull(item.getUnitPrice());
+        assertNull(item.getCategory());
+    }
+
+    @Test
+    void shouldCreateItemWithBasicParameters() {
+        Item item = new Item("Laptop", "Gaming laptop", 1, new BigDecimal("1500.00"));
+        assertEquals("Laptop", item.getName());
+        assertEquals("Gaming laptop", item.getDescription());
+        assertEquals(1, item.getCategoryId());
+        assertEquals(new BigDecimal("1500.00"), item.getUnitPrice());
+    }
+
+    @Test
+    void shouldCreateItemWithCategory() {
+        Category category = new Category("Electronics", "Electronic devices");
+        Item item = new Item("Smartphone", "Latest model smartphone", category, new BigDecimal("800.00"));
+        assertEquals("Smartphone", item.getName());
+        assertEquals("Latest model smartphone", item.getDescription());
+        assertEquals(category, item.getCategory());
+        assertEquals(new BigDecimal("800.00"), item.getUnitPrice());
+    }
+
+    @Test
+    void shouldSetAndGetItemId() {
+        Item item = new Item();
+        item.setItemId(123);
+        assertEquals(123, item.getItemId());
+    }
+
+    @Test
+    void shouldSetAndGetName() {
+        Item item = new Item();
+        item.setName("Tablet");
+        assertEquals("Tablet", item.getName());
+    }
+
+    @Test
+    void shouldSetAndGetDescription() {
+        Item item = new Item();
+        item.setDescription("10-inch tablet");
+        assertEquals("10-inch tablet", item.getDescription());
+    }
+
+    @Test
+    void shouldSetAndGetCategoryId() {
+        Item item = new Item();
+        item.setCategoryId(5);
+        assertEquals(5, item.getCategoryId());
+    }
+
+    @Test
+    void shouldSetAndGetUnitPrice() {
+        Item item = new Item();
+        item.setUnitPrice(new BigDecimal("299.99"));
+        assertEquals(new BigDecimal("299.99"), item.getUnitPrice());
+    }
+
+    @Test
+    void shouldSetAndGetCategory() {
+        Item item = new Item();
+        Category category = new Category("Books", "Educational books");
+        item.setCategory(category);
+        assertEquals(category, item.getCategory());
+    }
+
+    @Test
+    void shouldSetAndGetCreatedAt() {
+        Item item = new Item();
+        LocalDateTime now = LocalDateTime.now();
+        item.setCreatedAt(now);
+        assertEquals(now, item.getCreatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetUpdatedAt() {
+        Item item = new Item();
+        LocalDateTime now = LocalDateTime.now();
+        item.setUpdatedAt(now);
+        assertEquals(now, item.getUpdatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetDeletedAt() {
+        Item item = new Item();
+        LocalDateTime now = LocalDateTime.now();
+        item.setDeletedAt(now);
+        assertEquals(now, item.getDeletedAt());
+    }
+
+    @Test
+    void shouldReturnCategoryName() {
+        Category category = new Category("Software", "Software applications");
+        Item item = new Item();
+        item.setCategory(category);
+        assertEquals("Software", item.getCategoryName());
+    }
+
+    @Test
+    void shouldReturnNullCategoryNameWhenNoCategory() {
+        Item item = new Item();
+        assertNull(item.getCategoryName());
+    }
+}

--- a/src/test/java/com/pahanaedu/model/UserTest.java
+++ b/src/test/java/com/pahanaedu/model/UserTest.java
@@ -1,0 +1,117 @@
+package com.pahanaedu.model;
+
+import com.pahanaedu.enums.UserRole;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+    @Test
+    void shouldCreateDefaultUser() {
+        User user = new User();
+        assertNotNull(user);
+        assertEquals(0, user.getUserId());
+        assertNull(user.getEmail());
+        assertNull(user.getPassword());
+        assertNull(user.getFirstName());
+        assertNull(user.getLastName());
+        assertNull(user.getRole());
+    }
+
+    @Test
+    void shouldCreateUserWithParameters() {
+        User user = new User("test@example.com", "password123", "John", "Doe", UserRole.ADMIN);
+        assertEquals("test@example.com", user.getEmail());
+        assertEquals("password123", user.getPassword());
+        assertEquals("John", user.getFirstName());
+        assertEquals("Doe", user.getLastName());
+        assertEquals("ADMIN", user.getRole());
+    }
+
+    @Test
+    void shouldSetAndGetUserId() {
+        User user = new User();
+        user.setUserId(123);
+        assertEquals(123, user.getUserId());
+    }
+
+    @Test
+    void shouldSetAndGetEmail() {
+        User user = new User();
+        user.setEmail("test@example.com");
+        assertEquals("test@example.com", user.getEmail());
+    }
+
+    @Test
+    void shouldSetAndGetPassword() {
+        User user = new User();
+        user.setPassword("secret123");
+        assertEquals("secret123", user.getPassword());
+    }
+
+    @Test
+    void shouldSetAndGetFirstName() {
+        User user = new User();
+        user.setFirstName("Alice");
+        assertEquals("Alice", user.getFirstName());
+    }
+
+    @Test
+    void shouldSetAndGetLastName() {
+        User user = new User();
+        user.setLastName("Smith");
+        assertEquals("Smith", user.getLastName());
+    }
+
+    @Test
+    void shouldSetAndGetRole() {
+        User user = new User();
+        user.setRole(UserRole.CASHIER);
+        assertEquals("CASHIER", user.getRole());
+    }
+
+    @Test
+    void shouldSetAndGetCreatedAt() {
+        User user = new User();
+        LocalDateTime now = LocalDateTime.now();
+        user.setCreatedAt(now);
+        assertEquals(now, user.getCreatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetUpdatedAt() {
+        User user = new User();
+        LocalDateTime now = LocalDateTime.now();
+        user.setUpdatedAt(now);
+        assertEquals(now, user.getUpdatedAt());
+    }
+
+    @Test
+    void shouldSetAndGetDeletedAt() {
+        User user = new User();
+        LocalDateTime now = LocalDateTime.now();
+        user.setDeletedAt(now);
+        assertEquals(now, user.getDeletedAt());
+    }
+
+    @Test
+    void shouldReturnFullName() {
+        User user = new User("test@example.com", "password", "John", "Doe", UserRole.ADMIN);
+        assertEquals("John Doe", user.getFullName());
+    }
+
+    @Test
+    void shouldCheckIfAdmin() {
+        User adminUser = new User("admin@example.com", "password", "Admin", "User", UserRole.ADMIN);
+        User cashierUser = new User("cashier@example.com", "password", "Cashier", "User", UserRole.CASHIER);
+
+        assertTrue(adminUser.isAdmin());
+        assertFalse(cashierUser.isAdmin());
+    }
+
+    @Test
+    void shouldReturnRoleCssClass() {
+        User user = new User("test@example.com", "password", "Test", "User", UserRole.ADMIN);
+        assertEquals("role-admin", user.getRoleCssClass());
+    }
+}

--- a/src/test/java/com/pahanaedu/service/AuthServiceTest.java
+++ b/src/test/java/com/pahanaedu/service/AuthServiceTest.java
@@ -1,0 +1,117 @@
+package com.pahanaedu.service;
+
+import com.pahanaedu.dao.UserDAO;
+import com.pahanaedu.model.User;
+import com.pahanaedu.enums.UserRole;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserDAO userDAO;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(userDAO);
+    }
+
+    @Test
+    void shouldCreateAuthServiceWithDefaultConstructor() {
+        AuthService service = new AuthService();
+        assertNotNull(service);
+    }
+
+    @Test
+    void shouldCreateAuthServiceWithUserDAO() {
+        AuthService service = new AuthService(userDAO);
+        assertNotNull(service);
+    }
+
+    @Test
+    void shouldReturnNullForInvalidInputs() {
+        assertNull(authService.authenticate(null, "password"));
+        assertNull(authService.authenticate("email@test.com", null));
+        assertNull(authService.authenticate("", "password"));
+        assertNull(authService.authenticate("email@test.com", ""));
+        assertNull(authService.authenticate("   ", "password"));
+        assertNull(authService.authenticate("email@test.com", "   "));
+        assertNull(authService.authenticate(null, null));
+        assertNull(authService.authenticate("", ""));
+
+        verifyNoInteractions(userDAO);
+    }
+
+    @Test
+    void shouldReturnNullWhenUserNotFound() {
+        String email = "nonexistent@test.com";
+        String password = "password123";
+
+        when(userDAO.getUserByEmail(email)).thenReturn(null);
+
+        User result = authService.authenticate(email, password);
+
+        assertNull(result);
+        verify(userDAO).getUserByEmail(email);
+        verify(userDAO, never()).updateLastLogin(anyInt());
+    }
+
+    @Test
+    void shouldReturnNullWhenPasswordIncorrect() {
+        String email = "test@example.com";
+        String password = "wrongPassword";
+        User mockUser = new User(email, "correctPassword", "John", "Doe", UserRole.ADMIN);
+        mockUser.setUserId(1);
+
+        when(userDAO.getUserByEmail(email)).thenReturn(mockUser);
+
+        User result = authService.authenticate(email, password);
+
+        assertNull(result);
+        verify(userDAO).getUserByEmail(email);
+        verify(userDAO, never()).updateLastLogin(anyInt());
+    }
+
+    @Test
+    void shouldReturnUserWhenCredentialsValid() {
+        String email = "test@example.com";
+        String password = "correctPassword";
+        User mockUser = new User(email, password, "John", "Doe", UserRole.ADMIN);
+        mockUser.setUserId(1);
+
+        when(userDAO.getUserByEmail(email)).thenReturn(mockUser);
+
+        User result = authService.authenticate(email, password);
+
+        assertNotNull(result);
+        assertEquals(mockUser, result);
+        verify(userDAO).getUserByEmail(email);
+        verify(userDAO).updateLastLogin(1);
+    }
+
+    @Test
+    void shouldTrimAndLowercaseEmail() {
+        String email = "  TEST@EXAMPLE.COM  ";
+        String expectedEmail = "test@example.com";
+        String password = "password123";
+        User mockUser = new User(expectedEmail, password, "John", "Doe", UserRole.ADMIN);
+        mockUser.setUserId(1);
+
+        when(userDAO.getUserByEmail(expectedEmail)).thenReturn(mockUser);
+
+        User result = authService.authenticate(email, password);
+
+        assertNotNull(result);
+        assertEquals(mockUser, result);
+        verify(userDAO).getUserByEmail(expectedEmail);
+        verify(userDAO).updateLastLogin(1);
+    }
+}

--- a/src/test/java/com/pahanaedu/util/PasswordUtilTest.java
+++ b/src/test/java/com/pahanaedu/util/PasswordUtilTest.java
@@ -1,0 +1,56 @@
+package com.pahanaedu.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordUtilTest {
+
+    @Test
+    void shouldHashPasswordAsPlainText() {
+        String password = "testPassword123";
+        String hashedPassword = PasswordUtil.hashPassword(password);
+        assertNotNull(hashedPassword);
+        assertEquals(password, hashedPassword);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldHandleInvalidPasswordsForHashing(String password) {
+        String hashedPassword = PasswordUtil.hashPassword(password);
+        assertEquals(password, hashedPassword);
+    }
+
+    @Test
+    void shouldVerifyMatchingPasswords() {
+        String password = "myPassword123";
+        assertTrue(PasswordUtil.verifyPassword(password, password));
+    }
+
+    @Test
+    void shouldRejectDifferentPasswords() {
+        assertFalse(PasswordUtil.verifyPassword("wrongPassword", "correctPassword"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "password with spaces", "p@ssw0rd!#$%", "123456789" })
+    void shouldVerifyVariousPasswordFormats(String password) {
+        assertTrue(PasswordUtil.verifyPassword(password, password));
+    }
+
+    @Test
+    void shouldHandleNullInputsInVerification() {
+        assertFalse(PasswordUtil.verifyPassword(null, "password"));
+        assertFalse(PasswordUtil.verifyPassword("password", null));
+        assertFalse(PasswordUtil.verifyPassword(null, null));
+    }
+
+    @Test
+    void shouldHandleEmptyInputsInVerification() {
+        assertTrue(PasswordUtil.verifyPassword("", ""));
+        assertFalse(PasswordUtil.verifyPassword("", "password"));
+        assertFalse(PasswordUtil.verifyPassword("password", ""));
+    }
+}


### PR DESCRIPTION
- Implement CategoryDAOTest to validate CRUD operations for categories.
- Implement CustomerDAOTest to validate CRUD operations for customers.
- Implement ItemDAOTest to validate CRUD operations for items and category associations.
- Implement UserDAOTest to validate CRUD operations for users and email checks.
- Enhance AuthServiceTest to validate user authentication and email handling.
- Set up database state before tests to ensure consistent test results.